### PR TITLE
visibility - Default in search filter - release-3.5.0

### DIFF
--- a/content-api/content-actors/src/test/scala/org/sunbird/content/actors/TestChannelActor.scala
+++ b/content-api/content-actors/src/test/scala/org/sunbird/content/actors/TestChannelActor.scala
@@ -60,7 +60,7 @@ class TestChannelActor extends BaseSpec with MockFactory {
     assert("failed".equals(response.getParams.getStatus))
   }
 
-  it should "return success response for 'readChannel' operation" in {
+  ignore should "return success response for 'readChannel' operation" in {
     implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
     val graphDB = mock[GraphService]
     (oec.graphService _).expects().returns(graphDB)

--- a/content-api/content-actors/src/test/scala/org/sunbird/content/actors/TestChannelActor.scala
+++ b/content-api/content-actors/src/test/scala/org/sunbird/content/actors/TestChannelActor.scala
@@ -60,7 +60,7 @@ class TestChannelActor extends BaseSpec with MockFactory {
     assert("failed".equals(response.getParams.getStatus))
   }
 
-  ignore should "return success response for 'readChannel' operation" in {
+  it should "return success response for 'readChannel' operation" in {
     implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
     val graphDB = mock[GraphService]
     (oec.graphService _).expects().returns(graphDB)

--- a/search-api/search-actors/src/test/java/org/sunbird/actors/SearchActorTest.java
+++ b/search-api/search-actors/src/test/java/org/sunbird/actors/SearchActorTest.java
@@ -780,6 +780,8 @@ public class SearchActorTest extends SearchBaseActorTest {
         Response resp = getSearchResponse(req);
         result = resp.getResult();
         Assert.assertNotNull(result.get("content"));
+        List<Object> contents = (List<Object>) result.getOrDefault("content", new ArrayList<Object>());
+        Assert.assertEquals(contents.size(), 35);
     }
 
     @Test

--- a/search-api/search-actors/src/test/java/org/sunbird/actors/SearchBaseActorTest.java
+++ b/search-api/search-actors/src/test/java/org/sunbird/actors/SearchBaseActorTest.java
@@ -200,6 +200,7 @@ public class SearchBaseActorTest {
         if (null != tagList && !tagList.isEmpty() && index % 7 != 0)
             map.put("keywords", tagList);
         map.put("downloads", index);
+        map.put("visibility", "Default");
         return map;
     }
 


### PR DESCRIPTION
Using `visibility: Default` in search filter when it is not given in filters list.