### PR TITLE
SB-24310: Adding framework master category validation configuration

### DIFF
--- a/ontology-engine/graph-engine_2.11/src/main/scala/org/sunbird/graph/schema/validator/FrameworkValidator.scala
+++ b/ontology-engine/graph-engine_2.11/src/main/scala/org/sunbird/graph/schema/validator/FrameworkValidator.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletionException
 import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
 import org.sunbird.cache.impl.RedisCache
+import org.sunbird.common.Platform
 import org.sunbird.common.exception.{ClientException, ResourceNotFoundException, ServerException}
 import org.sunbird.graph.OntologyEngineContext
 import org.sunbird.graph.common.enums.SystemProperties
@@ -23,7 +24,7 @@ trait FrameworkValidator extends IDefinition {
   abstract override def validate(node: Node, operation: String, setDefaultValue: Boolean)(implicit ec: ExecutionContext, oec: OntologyEngineContext): Future[Node] = {
     val fwCategories: List[String] = schemaValidator.getConfig.getStringList("frameworkCategories").asScala.toList
     val graphId: String = if(StringUtils.isNotBlank(node.getGraphId)) node.getGraphId else "domain"
-    val orgAndTargetFWData: Future[(List[String], List[String])] = getOrgAndTargetFWData(graphId, "Category")
+    val orgAndTargetFWData: Future[(List[String], List[String])] = if(Platform.getBoolean("master.category.validation.enabled",true)) getOrgAndTargetFWData(graphId, "Category") else Future(List(), List())
 
     orgAndTargetFWData.map(orgAndTargetTouple => {
       val orgFwTerms = orgAndTargetTouple._1


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-24310" title="SB-24310" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SB-24310</a>  Tagging org and target framework values for assets created under a target collection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Adding framework master category validation configuration

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] createNode with fetching FrameworkMasterCategoryMap from DB should create a node successfully
- [X] createNode with enriching FrameworkMasterCategoryMap should create a node successfully

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions:

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
