### PR TITLE
SC-2296: Adding interception points to the content schema

### DIFF
--- a/schemas/content/1.0/schema.json
+++ b/schemas/content/1.0/schema.json
@@ -595,6 +595,12 @@
                 ]
             }
         },
+        "interceptionPoints": {
+            "type": "array",
+            "items": {
+                "type": "object"
+            }
+        },
         "feedback": {
             "type": "array",
             "items": {

--- a/schemas/content/1.0/schema.json
+++ b/schemas/content/1.0/schema.json
@@ -599,7 +599,14 @@
             "type": "array",
             "items": {
                 "type": "object"
-            }
+            },
+            "default": []
+        },
+        "interceptionType": {
+            "type": "string",
+            "enum": [
+                "Timestamp"
+            ]
         },
         "feedback": {
             "type": "array",


### PR DESCRIPTION
This change adds interception points to the content model. The interception points will be supported only for videos in V1, but the change is to the base model so that in the future, this can easily be applied to other content types.

The interception points represent when the content will be intercepted, and with what other type of content. For example, in V1, videos can be intercepted by QuML question sets.

A sample interception for a video would be:

```json
   "interceptionPoints":{
      "items":[
         {
            "type":"QuestionSet",
            "interceptionPoint":3000,
            "identifier":"ID"
         },
         {
            "type":"QuestionSet",
            "interceptionPoint":9000,
            "identifier":"ID"
         },
         {
            "type":"QuestionSet",
            "interceptionPoint":300,
            "identifier":"ID"
         }
      ]
   },
   "interceptionType":"Timestamp"
```

Timestamp would be an integer that would represent the number of seconds into the video where the interceptions should appear.


### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

