### PR TITLE
SB-25071 fix: Added mimeType validation to AssetMimeTypeMgr

### DIFF
--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManager.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManager.scala
@@ -41,6 +41,7 @@ class BaseMimeTypeManager(implicit ss: StorageService) {
 
 	protected val UPLOAD_DENIED_ERR_MSG = "FILE_UPLOAD_ERROR | Upload operation not supported for given mimeType"
 	val COMPOSED_H5P_ZIP: String = "composed-h5p-zip"
+	val mimeTypesToValidate: List[String] = if (Platform.config.hasPath("validation.strictMimeType")) Platform.config.getStringList("validation.strictMimeType").asScala.toList else List("image/svg+xml")
 
 	def validateUploadRequest(objectId: String, node: Node, data: AnyRef)(implicit ec: ExecutionContext): Unit = {
 		if (StringUtils.isBlank(objectId))

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImpl.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImpl.scala
@@ -2,12 +2,11 @@ package org.sunbird.mimetype.mgr.impl
 
 import java.io.File
 
-import org.apache.commons.lang3.StringUtils
-import org.sunbird.models.UploadParams
 import org.sunbird.cloudstore.StorageService
 import org.sunbird.common.exception.ClientException
 import org.sunbird.graph.dac.model.Node
 import org.sunbird.mimetype.mgr.{BaseMimeTypeManager, MimeTypeManager}
+import org.sunbird.models.UploadParams
 import org.sunbird.telemetry.logger.TelemetryManager
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,7 +16,7 @@ class AssetMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
 	override def upload(objectId: String, node: Node, uploadFile: File, filePath: Option[String], params: UploadParams)(implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
 		validateUploadRequest(objectId, node, uploadFile)
 		val nodeMimeType = node.getMetadata.getOrDefault("mimeType", "").asInstanceOf[String]
-		if (!isValidMimeType(uploadFile, nodeMimeType)) {
+		if (mimeTypesToValidate.contains(nodeMimeType) && !isValidMimeType(uploadFile, nodeMimeType)) {
 			TelemetryManager.log("Uploaded File MimeType is not same as Asset MimeType. [Asset MimeType: " + nodeMimeType + "]")
 			throw new ClientException("VALIDATION_ERROR", "Uploaded File MimeType is not same as Asset MimeType.")
 		}

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImpl.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImpl.scala
@@ -16,9 +16,10 @@ class AssetMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
 	override def upload(objectId: String, node: Node, uploadFile: File, filePath: Option[String], params: UploadParams)(implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
 		validateUploadRequest(objectId, node, uploadFile)
 		val nodeMimeType = node.getMetadata.getOrDefault("mimeType", "").asInstanceOf[String]
-		if (mimeTypesToValidate.contains(nodeMimeType) && !isValidMimeType(uploadFile, nodeMimeType)) {
+		if (!isValidMimeType(uploadFile, nodeMimeType)) {
 			TelemetryManager.log("Uploaded File MimeType is not same as Asset MimeType. [Asset MimeType: " + nodeMimeType + "]")
-			throw new ClientException("VALIDATION_ERROR", "Uploaded File MimeType is not same as Asset MimeType.")
+			if(mimeTypesToValidate.contains(nodeMimeType))
+				throw new ClientException("VALIDATION_ERROR", "Uploaded File MimeType is not same as Asset MimeType.")
 		}
 		val result: Array[String] = uploadArtifactToCloud(uploadFile, objectId, filePath)
 		//TODO: depreciate s3Key. use cloudStorageKey instead

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImpl.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImpl.scala
@@ -16,11 +16,10 @@ class AssetMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
 
 	override def upload(objectId: String, node: Node, uploadFile: File, filePath: Option[String], params: UploadParams)(implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
 		validateUploadRequest(objectId, node, uploadFile)
-		val fileMimeType = getFileMimeType(uploadFile)
 		val nodeMimeType = node.getMetadata.getOrDefault("mimeType", "").asInstanceOf[String]
-		TelemetryManager.log("Uploading Asset MimeType: " + fileMimeType)
-		if (!StringUtils.equalsIgnoreCase(fileMimeType, nodeMimeType)) {
-			TelemetryManager.log("Uploaded File MimeType is not same as Node (Object) MimeType. [Uploading MimeType: " + fileMimeType + " | Node (Object) MimeType: " + nodeMimeType + "]")
+		if (!isValidMimeType(uploadFile, nodeMimeType)) {
+			TelemetryManager.log("Uploaded File MimeType is not same as Asset MimeType. [Asset MimeType: " + nodeMimeType + "]")
+			throw new ClientException("VALIDATION_ERROR", "Uploaded File MimeType is not same as Asset MimeType.")
 		}
 		val result: Array[String] = uploadArtifactToCloud(uploadFile, objectId, filePath)
 		//TODO: depreciate s3Key. use cloudStorageKey instead

--- a/platform-modules/mimetype-manager/src/test/resources/application.conf
+++ b/platform-modules/mimetype-manager/src/test/resources/application.conf
@@ -476,3 +476,6 @@ cloud_storage_type="azure"
 azure_storage_key="asdfgh"
 azure_storage_secret="jhgfdcvb"
 azure_storage_container="sunbird-content-dev"
+
+
+validation.strictMimeType = ["image/svg+xml"]

--- a/platform-modules/mimetype-manager/src/test/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImplTest.scala
+++ b/platform-modules/mimetype-manager/src/test/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImplTest.scala
@@ -78,7 +78,7 @@ class AssetMimeTypeMgrImplTest extends AsyncFlatSpec with Matchers with AsyncMoc
 
   "upload with invalid mimeType" should "throw client exception" in {
     val node = getNode()
-    node.getMetadata.put("mimeType", "application/pdf")
+    node.getMetadata.put("mimeType", "image/svg+xml")
     val exception = intercept[ClientException] {
       new AssetMimeTypeMgrImpl().upload("do_123", node, new File(Resources.getResource("filesToZip/human_vs_robot-.jpg").toURI), None, UploadParams())
     }

--- a/platform-modules/mimetype-manager/src/test/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImplTest.scala
+++ b/platform-modules/mimetype-manager/src/test/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImplTest.scala
@@ -18,7 +18,7 @@ class AssetMimeTypeMgrImplTest extends AsyncFlatSpec with Matchers with AsyncMoc
 
   "upload with valid file" should "return artifactUrl with successful response" in {
     val node = getNode()
-    node.getMetadata.put("mimeType", "image/jpg")
+    node.getMetadata.put("mimeType", "image/jpeg")
     val identifier = "do_123"
     implicit val ss = mock[StorageService]
     (ss.uploadFile(_:String, _: File, _: Option[Boolean])).expects(*, *, *).returns(Array(identifier, identifier))
@@ -74,6 +74,15 @@ class AssetMimeTypeMgrImplTest extends AsyncFlatSpec with Matchers with AsyncMoc
       assert("do_123" == result.getOrElse("identifier", ""))
       assert(inputUrl == result.getOrElse("artifactUrl", ""))
     })
+  }
+
+  "upload with invalid mimeType" should "throw client exception" in {
+    val node = getNode()
+    node.getMetadata.put("mimeType", "application/pdf")
+    val exception = intercept[ClientException] {
+      new AssetMimeTypeMgrImpl().upload("do_123", node, new File(Resources.getResource("filesToZip/human_vs_robot-.jpg").toURI), None, UploadParams())
+    }
+    exception.getMessage shouldEqual "Uploaded File MimeType is not same as Asset MimeType."
   }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-25071" title="SB-25071" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />SB-25071</a>  Created certificate templates are not showing up even after refreshing multiple times.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
