### PR TITLE
SB-25071 fix: Added mimeType validation to AssetMimeTypeMgr

### DIFF
--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImpl.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/AssetMimeTypeMgrImpl.scala
@@ -18,7 +18,7 @@ class AssetMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
 		val nodeMimeType = node.getMetadata.getOrDefault("mimeType", "").asInstanceOf[String]
 		if (!isValidMimeType(uploadFile, nodeMimeType)) {
 			TelemetryManager.log("Uploaded File MimeType is not same as Asset MimeType. [Asset MimeType: " + nodeMimeType + "]")
-			if(mimeTypesToValidate.contains(nodeMimeType))
+			if(mimeTypesToValidate.contains(nodeMimeType) || mimeTypesToValidate.contains(getFileMimeType(uploadFile)))
 				throw new ClientException("VALIDATION_ERROR", "Uploaded File MimeType is not same as Asset MimeType.")
 		}
 		val result: Array[String] = uploadArtifactToCloud(uploadFile, objectId, filePath)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-25071" title="SB-25071" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />SB-25071</a>  Created certificate templates are not showing up even after refreshing multiple times.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
