### PR TITLE
Issue #SB-25036 feat: Question set offline consumption feature. 

### DIFF
--- a/assessment-api/assessment-actors/src/main/scala/org/sunbird/actors/QuestionActor.scala
+++ b/assessment-api/assessment-actors/src/main/scala/org/sunbird/actors/QuestionActor.scala
@@ -41,6 +41,7 @@ class QuestionActor @Inject()(implicit oec: OntologyEngineContext) extends BaseA
 	def update(request: Request): Future[Response] = {
 		RequestUtil.restrictProperties(request)
 		request.getRequest.put("identifier", request.getContext.get("identifier"))
+		request.getRequest.put("artifactUrl",null)
 		AssessmentManager.getValidatedNodeForUpdate(request, "ERR_QUESTION_UPDATE").flatMap(_ => AssessmentManager.updateNode(request))
 	}
 

--- a/schemas/question/1.0/schema.json
+++ b/schemas/question/1.0/schema.json
@@ -338,6 +338,10 @@
     "createdBy": {
       "type": "string"
     },
+    "artifactUrl": {
+      "type": "string",
+      "format": "url"
+    },
     "lastUpdatedOn": {
       "type": "string"
     },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-25036" title="SB-25036" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SB-25036</a>  Create full ecar for questionset for offline consumption
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Issue #SB-25036 feat: Question set offline consumption feature. As part of feature enabling, while publishing the question as part of the questionset, artifactUrl is being generated and set. In order to address the artifactUrl when the question gets updated, code to set artifactUrl to null is implemented.


### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran Unit Tests

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

