### PR TITLE
SB-25737 - Question & QuestionSet Private Read API

### DIFF
--- a/assessment-api/assessment-actors/src/main/scala/org/sunbird/actors/QuestionActor.scala
+++ b/assessment-api/assessment-actors/src/main/scala/org/sunbird/actors/QuestionActor.scala
@@ -28,6 +28,7 @@ class QuestionActor @Inject()(implicit oec: OntologyEngineContext) extends BaseA
 	override def onReceive(request: Request): Future[Response] = request.getOperation match {
 		case "createQuestion" => AssessmentManager.create(request, "ERR_QUESTION_CREATE")
 		case "readQuestion" => AssessmentManager.read(request, "question")
+		case "readPrivateQuestion" => AssessmentManager.privateRead(request, "question")
 		case "updateQuestion" => update(request)
 		case "reviewQuestion" => review(request)
 		case "publishQuestion" => publish(request)

--- a/assessment-api/assessment-actors/src/main/scala/org/sunbird/actors/QuestionSetActor.scala
+++ b/assessment-api/assessment-actors/src/main/scala/org/sunbird/actors/QuestionSetActor.scala
@@ -28,6 +28,7 @@ class QuestionSetActor @Inject()(implicit oec: OntologyEngineContext) extends Ba
 	override def onReceive(request: Request): Future[Response] = request.getOperation match {
 		case "createQuestionSet" => AssessmentManager.create(request, "ERR_QUESTION_SET_CREATE")
 		case "readQuestionSet" => AssessmentManager.read(request, "questionset")
+		case "readPrivateQuestionSet" => AssessmentManager.privateRead(request, "questionset")
 		case "updateQuestionSet" => update(request)
 		case "reviewQuestionSet" => review(request)
 		case "publishQuestionSet" => publish(request)

--- a/assessment-api/assessment-actors/src/main/scala/org/sunbird/managers/AssessmentManager.scala
+++ b/assessment-api/assessment-actors/src/main/scala/org/sunbird/managers/AssessmentManager.scala
@@ -43,6 +43,27 @@ object AssessmentManager {
 		})
 	}
 
+	def privateRead(request: Request, resName: String)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Response] = {
+		val fields: util.List[String] = JavaConverters.seqAsJavaListConverter(request.get("fields").asInstanceOf[String].split(",").filter(field => StringUtils.isNotBlank(field) && !StringUtils.equalsIgnoreCase(field, "null"))).asJava
+		request.getRequest.put("fields", fields)
+		if (StringUtils.isBlank(request.getRequest.getOrDefault("channel", "").asInstanceOf[String])) throw new ClientException("ERR_INVALID_CHANNEL", "Please Provide Channel!")
+		DataNode.read(request).map(node => {
+			val metadata: util.Map[String, AnyRef] = NodeUtil.serialize(node, fields, node.getObjectType.toLowerCase.replace("Image", ""), request.getContext.get("version").asInstanceOf[String])
+			metadata.put("identifier", node.getIdentifier.replace(".img", ""))
+			if(StringUtils.equalsIgnoreCase(metadata.getOrDefault("visibility", "").asInstanceOf[String],"Private")) {
+				if (StringUtils.equalsIgnoreCase(metadata.getOrDefault("channel", "").asInstanceOf[String],request.getRequest.getOrDefault("channel", "").asInstanceOf[String])) {
+					ResponseHandler.OK.put(resName, metadata)
+				}
+				else {
+					throw new ClientException("ERR_INCORRECT_CHANNEL", "Channel id is not matched")
+				}
+			}
+			else {
+				throw new ClientException("ERR_ACCESS_DENIED", "Content visibility is default, public or parent. Cannot be accessed through private api")
+			}
+		})
+	}
+
 	def updateNode(request: Request)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Response] = {
 		DataNode.update(request).map(node => {
 			ResponseHandler.OK.putAll(Map("identifier" -> node.getIdentifier.replace(".img", ""), "versionKey" -> node.getMetadata.get("versionKey")).asJava)

--- a/assessment-api/assessment-actors/src/main/scala/org/sunbird/managers/AssessmentManager.scala
+++ b/assessment-api/assessment-actors/src/main/scala/org/sunbird/managers/AssessmentManager.scala
@@ -50,17 +50,12 @@ object AssessmentManager {
 		DataNode.read(request).map(node => {
 			val metadata: util.Map[String, AnyRef] = NodeUtil.serialize(node, fields, node.getObjectType.toLowerCase.replace("Image", ""), request.getContext.get("version").asInstanceOf[String])
 			metadata.put("identifier", node.getIdentifier.replace(".img", ""))
-			if(StringUtils.equalsIgnoreCase(metadata.getOrDefault("visibility", "").asInstanceOf[String],"Private")) {
 				if (StringUtils.equalsIgnoreCase(metadata.getOrDefault("channel", "").asInstanceOf[String],request.getRequest.getOrDefault("channel", "").asInstanceOf[String])) {
 					ResponseHandler.OK.put(resName, metadata)
 				}
 				else {
 					throw new ClientException("ERR_INCORRECT_CHANNEL", "Channel id is not matched")
 				}
-			}
-			else {
-				throw new ClientException("ERR_ACCESS_DENIED", "Content visibility is default, public or parent. Cannot be accessed through private api")
-			}
 		})
 	}
 

--- a/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionActorTest.scala
+++ b/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionActorTest.scala
@@ -1,11 +1,11 @@
 package org.sunbird.actors
 import java.util
-
 import akka.actor.Props
 import org.scalamock.scalatest.MockFactory
 import org.sunbird.common.HttpUtil
 import org.sunbird.common.dto.ResponseHandler
 import org.sunbird.common.dto.{Property, Request, Response}
+import org.sunbird.common.exception.ResponseCode
 import org.sunbird.graph.dac.model.{Node, SearchCriteria}
 import org.sunbird.graph.utils.ScalaJsonUtils
 import org.sunbird.graph.{GraphService, OntologyEngineContext}
@@ -53,6 +53,87 @@ class QuestionActorTest extends BaseSpec with MockFactory {
 		request.setOperation("readQuestion")
 		val response = callActor(request, Props(new QuestionActor()))
 		assert("successful".equals(response.getParams.getStatus))
+	}
+
+	it should "return success response for 'readPrivateQuestion'" in {
+		implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
+		val graphDB = mock[GraphService]
+		(oec.graphService _).expects().returns(graphDB)
+		val node = getNode("Question", Some(new util.HashMap[String, AnyRef]() {
+			{
+				put("name", "Question")
+				put("visibility","Private")
+				put("channel","abc-123")
+			}
+		}))
+		(graphDB.getNodeByUniqueId(_: String, _: String, _: Boolean, _: Request)).expects(*, *, *, *).returns(Future(node))
+		val request = getQuestionRequest()
+		request.getContext.put("identifier","do1234")
+		request.getRequest.put("channel", "abc-123")
+		request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
+		request.setOperation("readPrivateQuestion")
+		val response = callActor(request, Props(new QuestionActor()))
+		assert("successful".equals(response.getParams.getStatus))
+	}
+
+	it should "return client error for 'readPrivateQuestion' if channel is 'blank'" in {
+		implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
+		val graphDB = mock[GraphService]
+		val request = getQuestionRequest()
+		request.getContext.put("identifier","do1234")
+		request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
+		request.setOperation("readPrivateQuestion")
+		val response = callActor(request, Props(new QuestionActor()))
+		assert(response.getResponseCode == ResponseCode.CLIENT_ERROR)
+		assert(response.getParams.getErr == "ERR_INVALID_CHANNEL")
+		assert(response.getParams.getErrmsg == "Please Provide Channel!")
+	}
+
+	it should "return client error for 'readPrivateQuestion' if visibility is not 'Private'" in {
+		implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
+		val graphDB = mock[GraphService]
+		(oec.graphService _).expects().returns(graphDB)
+		val node = getNode("Question", Some(new util.HashMap[String, AnyRef]() {
+			{
+				put("name", "Question")
+				put("visibility","Public")
+				put("channel","abc-123")
+			}
+		}))
+		(graphDB.getNodeByUniqueId(_: String, _: String, _: Boolean, _: Request)).expects(*, *, *, *).returns(Future(node))
+		val request = getQuestionRequest()
+		request.getContext.put("identifier","do1234")
+		request.getRequest.put("channel", "abc-123")
+		request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
+		request.setOperation("readPrivateQuestion")
+		val response = callActor(request, Props(new QuestionActor()))
+		assert(response.getResponseCode == ResponseCode.CLIENT_ERROR)
+		assert(response.getParams.getErr == "ERR_ACCESS_DENIED")
+		assert(response.getParams.getErrmsg == "Content visibility is default, public or parent. Cannot be accessed through private api")
+	}
+
+	it should "return client error for 'readPrivateQuestion' if channel is mismatched" in {
+		implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
+		val graphDB = mock[GraphService]
+		(oec.graphService _).expects().returns(graphDB)
+		val node = getNode("Question", Some(new util.HashMap[String, AnyRef]() {
+			{
+				put("name", "Question")
+				put("visibility","Private")
+				put("channel","abc-123")
+			}
+		}))
+		(graphDB.getNodeByUniqueId(_: String, _: String, _: Boolean, _: Request)).expects(*, *, *, *).returns(Future(node)).anyNumberOfTimes()
+		val request = getQuestionRequest()
+		request.getContext.put("identifier","do1234")
+		request.getRequest.put("channel", "abc")
+		request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
+		request.setOperation("readPrivateQuestion")
+		val response = callActor(request, Props(new QuestionActor()))
+		assert(response.getResponseCode == ResponseCode.CLIENT_ERROR)
+		assert(response.getParams.getErr == "ERR_INCORRECT_CHANNEL")
+		assert(response.getParams.getErrmsg == "Channel id is not matched")
+
 	}
 
 	it should "return success response for 'updateQuestion'" in {

--- a/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionActorTest.scala
+++ b/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionActorTest.scala
@@ -89,29 +89,6 @@ class QuestionActorTest extends BaseSpec with MockFactory {
 		assert(response.getParams.getErrmsg == "Please Provide Channel!")
 	}
 
-	it should "return client error for 'readPrivateQuestion' if visibility is not 'Private'" in {
-		implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
-		val graphDB = mock[GraphService]
-		(oec.graphService _).expects().returns(graphDB)
-		val node = getNode("Question", Some(new util.HashMap[String, AnyRef]() {
-			{
-				put("name", "Question")
-				put("visibility","Public")
-				put("channel","abc-123")
-			}
-		}))
-		(graphDB.getNodeByUniqueId(_: String, _: String, _: Boolean, _: Request)).expects(*, *, *, *).returns(Future(node))
-		val request = getQuestionRequest()
-		request.getContext.put("identifier","do1234")
-		request.getRequest.put("channel", "abc-123")
-		request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
-		request.setOperation("readPrivateQuestion")
-		val response = callActor(request, Props(new QuestionActor()))
-		assert(response.getResponseCode == ResponseCode.CLIENT_ERROR)
-		assert(response.getParams.getErr == "ERR_ACCESS_DENIED")
-		assert(response.getParams.getErrmsg == "Content visibility is default, public or parent. Cannot be accessed through private api")
-	}
-
 	it should "return client error for 'readPrivateQuestion' if channel is mismatched" in {
 		implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
 		val graphDB = mock[GraphService]

--- a/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionSetActorTest.scala
+++ b/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionSetActorTest.scala
@@ -107,29 +107,6 @@ class QuestionSetActorTest extends BaseSpec with MockFactory {
         assert(response.getParams.getErrmsg == "Please Provide Channel!")
     }
 
-    it should "return client error for 'readPrivateQuestionSet' if visibility is not 'Private'" in {
-        implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
-        val graphDB = mock[GraphService]
-        (oec.graphService _).expects().returns(graphDB)
-        val node = getNode("QuestionSet", Some(new util.HashMap[String, AnyRef]() {
-            {
-                put("name", "QuestionSet")
-                put("visibility","Public")
-                put("channel","abc-123")
-            }
-        }))
-        (graphDB.getNodeByUniqueId(_: String, _: String, _: Boolean, _: Request)).expects(*, *, *, *).returns(Future(node))
-        val request = getQuestionSetRequest()
-        request.getContext.put("identifier","do1234")
-        request.getRequest.put("channel", "abc-123")
-        request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
-        request.setOperation("readPrivateQuestionSet")
-        val response = callActor(request, Props(new QuestionSetActor()))
-        assert(response.getResponseCode == ResponseCode.CLIENT_ERROR)
-        assert(response.getParams.getErr == "ERR_ACCESS_DENIED")
-        assert(response.getParams.getErrmsg == "Content visibility is default, public or parent. Cannot be accessed through private api")
-    }
-
     it should "return client error for 'readPrivateQuestionSet' if channel is mismatched" in {
         implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
         val graphDB = mock[GraphService]

--- a/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionSetActorTest.scala
+++ b/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionSetActorTest.scala
@@ -1,22 +1,21 @@
 package org.sunbird.actors
 
-import java.util
-
 import akka.actor.Props
 import org.scalamock.scalatest.MockFactory
 import org.sunbird.common.HttpUtil
-import org.sunbird.common.dto.{Property, Request, Response, ResponseHandler}
-import org.sunbird.graph.dac.model.{Node, Relation, SearchCriteria}
-import org.sunbird.graph.nodes.DataNode.getRelationMap
+import org.sunbird.common.dto.{Request, Response, ResponseHandler}
+import org.sunbird.common.exception.ResponseCode
+import org.sunbird.graph.dac.model.{Node, SearchCriteria}
 import org.sunbird.graph.utils.ScalaJsonUtils
 import org.sunbird.graph.{GraphService, OntologyEngineContext}
 import org.sunbird.kafka.client.KafkaClient
 import org.sunbird.utils.JavaJsonUtils
 
+import java.util
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class QuestionSetActorTest extends BaseSpec with MockFactory {
 
@@ -72,6 +71,86 @@ class QuestionSetActorTest extends BaseSpec with MockFactory {
         request.setOperation("readQuestionSet")
         val response = callActor(request, Props(new QuestionSetActor()))
         assert("successful".equals(response.getParams.getStatus))
+    }
+
+    it should "return success response for 'readPrivateQuestionSet'" in {
+        implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
+        val graphDB = mock[GraphService]
+        (oec.graphService _).expects().returns(graphDB)
+        val node = getNode("QuestionSet", Some(new util.HashMap[String, AnyRef]() {
+            {
+                put("name", "QuestionSet")
+                put("visibility","Private")
+                put("channel","abc-123")
+            }
+        }))
+        (graphDB.getNodeByUniqueId(_: String, _: String, _: Boolean, _: Request)).expects(*, *, *, *).returns(Future(node))
+        val request = getQuestionSetRequest()
+        request.getContext.put("identifier","do1234")
+        request.getRequest.put("channel", "abc-123")
+        request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
+        request.setOperation("readPrivateQuestionSet")
+        val response = callActor(request, Props(new QuestionSetActor()))
+        assert("successful".equals(response.getParams.getStatus))
+    }
+
+    it should "return client error for 'readPrivateQuestionSet' if channel is 'blank'" in {
+        implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
+        val graphDB = mock[GraphService]
+        val request = getQuestionSetRequest()
+        request.getContext.put("identifier","do1234")
+        request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
+        request.setOperation("readPrivateQuestionSet")
+        val response = callActor(request, Props(new QuestionSetActor()))
+        assert(response.getResponseCode == ResponseCode.CLIENT_ERROR)
+        assert(response.getParams.getErr == "ERR_INVALID_CHANNEL")
+        assert(response.getParams.getErrmsg == "Please Provide Channel!")
+    }
+
+    it should "return client error for 'readPrivateQuestionSet' if visibility is not 'Private'" in {
+        implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
+        val graphDB = mock[GraphService]
+        (oec.graphService _).expects().returns(graphDB)
+        val node = getNode("QuestionSet", Some(new util.HashMap[String, AnyRef]() {
+            {
+                put("name", "QuestionSet")
+                put("visibility","Public")
+                put("channel","abc-123")
+            }
+        }))
+        (graphDB.getNodeByUniqueId(_: String, _: String, _: Boolean, _: Request)).expects(*, *, *, *).returns(Future(node))
+        val request = getQuestionSetRequest()
+        request.getContext.put("identifier","do1234")
+        request.getRequest.put("channel", "abc-123")
+        request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
+        request.setOperation("readPrivateQuestionSet")
+        val response = callActor(request, Props(new QuestionSetActor()))
+        assert(response.getResponseCode == ResponseCode.CLIENT_ERROR)
+        assert(response.getParams.getErr == "ERR_ACCESS_DENIED")
+        assert(response.getParams.getErrmsg == "Content visibility is default, public or parent. Cannot be accessed through private api")
+    }
+
+    it should "return client error for 'readPrivateQuestionSet' if channel is mismatched" in {
+        implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
+        val graphDB = mock[GraphService]
+        (oec.graphService _).expects().returns(graphDB)
+        val node = getNode("QuestionSet", Some(new util.HashMap[String, AnyRef]() {
+            {
+                put("name", "QuestionSet")
+                put("visibility","Private")
+                put("channel","abc-123")
+            }
+        }))
+        (graphDB.getNodeByUniqueId(_: String, _: String, _: Boolean, _: Request)).expects(*, *, *, *).returns(Future(node)).anyNumberOfTimes()
+        val request = getQuestionSetRequest()
+        request.getContext.put("identifier","do1234")
+        request.getRequest.put("channel", "abc")
+        request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
+        request.setOperation("readPrivateQuestionSet")
+        val response = callActor(request, Props(new QuestionSetActor()))
+        assert(response.getResponseCode == ResponseCode.CLIENT_ERROR)
+        assert(response.getParams.getErr == "ERR_INCORRECT_CHANNEL")
+        assert(response.getParams.getErrmsg == "Channel id is not matched")
     }
 
     it should "return success response for 'updateQuestionSet'" in {

--- a/assessment-api/assessment-service/app/controllers/v4/QuestionController.scala
+++ b/assessment-api/assessment-service/app/controllers/v4/QuestionController.scala
@@ -35,6 +35,16 @@ class QuestionController @Inject()(@Named(ActorNames.QUESTION_ACTOR) questionAct
 		getResult(ApiId.READ_QUESTION, questionActor, questionRequest)
 	}
 
+	def privateRead(identifier: String, mode: Option[String], fields: Option[String]) = Action.async { implicit request =>
+		val headers = commonHeaders()
+		val question = new java.util.HashMap().asInstanceOf[java.util.Map[String, Object]]
+		question.putAll(headers)
+		question.putAll(Map("identifier" -> identifier, "fields" -> fields.getOrElse(""), "mode" -> mode.getOrElse("read")).asJava)
+		val questionRequest = getRequest(question, headers, QuestionOperations.readPrivateQuestion.toString)
+		setRequestContext(questionRequest, version, objectType, schemaName)
+		getResult(ApiId.READ_PRIVATE_QUESTION, questionActor, questionRequest)
+	}
+
 	def update(identifier: String) = Action.async { implicit request =>
 		val headers = commonHeaders()
 		val body = requestBody()

--- a/assessment-api/assessment-service/app/controllers/v4/QuestionSetController.scala
+++ b/assessment-api/assessment-service/app/controllers/v4/QuestionSetController.scala
@@ -35,6 +35,16 @@ class QuestionSetController @Inject()(@Named(ActorNames.QUESTION_SET_ACTOR) ques
 		getResult(ApiId.READ_QUESTION_SET, questionSetActor, questionSetRequest)
 	}
 
+	def privateRead(identifier: String, mode: Option[String], fields: Option[String]) = Action.async { implicit request =>
+		val headers = commonHeaders()
+		val questionSet = new java.util.HashMap().asInstanceOf[java.util.Map[String, Object]]
+		questionSet.putAll(headers)
+		questionSet.putAll(Map("identifier" -> identifier, "fields" -> fields.getOrElse(""), "mode" -> mode.getOrElse("read")).asJava)
+		val questionSetRequest = getRequest(questionSet, headers, QuestionSetOperations.readPrivateQuestionSet.toString)
+		setRequestContext(questionSetRequest, version, objectType, schemaName)
+		getResult(ApiId.READ_PRIVATE_QUESTION_SET, questionSetActor, questionSetRequest)
+	}
+
 	def update(identifier: String) = Action.async { implicit request =>
 		val headers = commonHeaders()
 		val body = requestBody()

--- a/assessment-api/assessment-service/app/utils/ApiId.scala
+++ b/assessment-api/assessment-service/app/utils/ApiId.scala
@@ -15,6 +15,7 @@ object ApiId {
 	//Question APIs
 	val CREATE_QUESTION = "api.question.create"
 	val READ_QUESTION = "api.question.read"
+	val READ_PRIVATE_QUESTION = "api.question.private.read"
 	val UPDATE_QUESTION = "api.question.update"
 	val REVIEW_QUESTION = "api.question.review"
 	val PUBLISH_QUESTION = "api.question.publish"
@@ -26,6 +27,7 @@ object ApiId {
 	//QuestionSet APIs
 	val CREATE_QUESTION_SET = "api.questionset.create"
 	val READ_QUESTION_SET = "api.questionset.read"
+	val READ_PRIVATE_QUESTION_SET = "api.questionset.private.read"
 	val UPDATE_QUESTION_SET = "api.questionset.update"
 	val REVIEW_QUESTION_SET = "api.questionset.review"
 	val PUBLISH_QUESTION_SET = "api.questionset.publish"

--- a/assessment-api/assessment-service/app/utils/QuestionOperations.scala
+++ b/assessment-api/assessment-service/app/utils/QuestionOperations.scala
@@ -1,5 +1,5 @@
 package utils
 
 object QuestionOperations extends Enumeration {
-	val createQuestion, readQuestion, updateQuestion, reviewQuestion, publishQuestion, retireQuestion, importQuestion, systemUpdateQuestion, listQuestions = Value
+	val createQuestion, readQuestion, readPrivateQuestion, updateQuestion, reviewQuestion, publishQuestion, retireQuestion, importQuestion, systemUpdateQuestion, listQuestions = Value
 }

--- a/assessment-api/assessment-service/app/utils/QuestionSetOperations.scala
+++ b/assessment-api/assessment-service/app/utils/QuestionSetOperations.scala
@@ -1,7 +1,7 @@
 package utils
 
 object QuestionSetOperations extends Enumeration {
-	val createQuestionSet, readQuestionSet, updateQuestionSet, reviewQuestionSet, publishQuestionSet,
+	val createQuestionSet, readQuestionSet, readPrivateQuestionSet, updateQuestionSet, reviewQuestionSet, publishQuestionSet,
 	retireQuestionSet, addQuestion, removeQuestion, updateHierarchyQuestion, readHierarchyQuestion,
 	rejectQuestionSet, importQuestionSet, systemUpdateQuestionSet = Value
 }

--- a/assessment-api/assessment-service/conf/routes
+++ b/assessment-api/assessment-service/conf/routes
@@ -14,6 +14,7 @@ DELETE    /itemset/v3/retire/:identifier    controllers.v3.ItemSetController.ret
 # Question API's
 POST      /question/v4/create                     controllers.v4.QuestionController.create
 GET       /question/v4/read/:identifier           controllers.v4.QuestionController.read(identifier:String, mode:Option[String], fields:Option[String])
+GET       /question/v4/private/read/:identifier   controllers.v4.QuestionController.privateRead(identifier:String, mode:Option[String], fields:Option[String])
 PATCH     /question/v4/update/:identifier         controllers.v4.QuestionController.update(identifier:String)
 POST      /question/v4/review/:identifier         controllers.v4.QuestionController.review(identifier:String)
 POST      /question/v4/publish/:identifier        controllers.v4.QuestionController.publish(identifier:String)
@@ -25,6 +26,7 @@ POST      /question/v4/list                       controllers.v4.QuestionControl
 # QuestionSet API's
 POST      /questionset/v4/create                     controllers.v4.QuestionSetController.create
 GET       /questionset/v4/read/:identifier           controllers.v4.QuestionSetController.read(identifier:String, mode:Option[String], fields:Option[String])
+GET       /questionset/v4/private/read/:identifier   controllers.v4.QuestionSetController.privateRead(identifier:String, mode:Option[String], fields:Option[String])
 PATCH     /questionset/v4/update/:identifier         controllers.v4.QuestionSetController.update(identifier:String)
 POST      /questionset/v4/review/:identifier         controllers.v4.QuestionSetController.review(identifier:String)
 POST      /questionset/v4/publish/:identifier        controllers.v4.QuestionSetController.publish(identifier:String)

--- a/assessment-api/assessment-service/test/controllers/v4/QuestionControllerSpec.scala
+++ b/assessment-api/assessment-service/test/controllers/v4/QuestionControllerSpec.scala
@@ -23,6 +23,12 @@ class QuestionControllerSpec extends BaseSpec {
 		status(result)(defaultAwaitTimeout) must equalTo(OK)
 	}
 
+	"private read should return an question successfully for given valid identifier" in {
+		val result = controller.privateRead("do_123", None, None)(FakeRequest())
+		isOK(result)
+		status(result)(defaultAwaitTimeout) must equalTo(OK)
+	}
+
 	"update should update the question successfully for given valid identifier" in {
 		val result = controller.update("do_123")(FakeRequest())
 		isOK(result)

--- a/assessment-api/assessment-service/test/controllers/v4/QuestionSetControllerSpec.scala
+++ b/assessment-api/assessment-service/test/controllers/v4/QuestionSetControllerSpec.scala
@@ -23,6 +23,12 @@ class QuestionSetControllerSpec extends BaseSpec {
 		status(result)(defaultAwaitTimeout) must equalTo(OK)
 	}
 
+	"private read should return an questionSet successfully for given valid identifier" in {
+		val result = controller.privateRead("do_123", None, None)(FakeRequest())
+		isOK(result)
+		status(result)(defaultAwaitTimeout) must equalTo(OK)
+	}
+
 	"update should update the questionSet successfully for given valid identifier" in {
 		val result = controller.update("do_123")(FakeRequest())
 		isOK(result)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-25737" title="SB-25737" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SB-25737</a>  Creation of a separate Private API Read and Search API Similar to the current APIs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

