### PR TITLE
Issue #SB-26691 fix: Description and keywords with doublequotes

### DIFF
--- a/content-api/collection-csv-actors/src/main/scala/org.sunbird/collectioncsv/manager/CollectionCSVManager.scala
+++ b/content-api/collection-csv-actors/src/main/scala/org.sunbird/collectioncsv/manager/CollectionCSVManager.scala
@@ -362,7 +362,7 @@ object CollectionCSVManager extends CollectionInputFileReader  {
       }).filter(node => node.nonEmpty).toList.distinct.mkString("[\"","\",\"","\"]")
     }
 
-    val hierarchyRootNode = s""""$collectionID": {"name":"$collectionName","contentType":"$collectionType","root":true,"children":$collectionL1NodeList}"""
+    val hierarchyRootNode = s""""$collectionID": {"name":$collectionName,"contentType":"$collectionType","root":true,"children":$collectionL1NodeList}"""
 
     val hierarchyChildNodesMetadata = if(mode.equals(CollectionTOCConstants.CREATE)) {
       folderInfoMap.map(record => {

--- a/content-api/collection-csv-actors/src/main/scala/org.sunbird/collectioncsv/manager/CollectionCSVManager.scala
+++ b/content-api/collection-csv-actors/src/main/scala/org.sunbird/collectioncsv/manager/CollectionCSVManager.scala
@@ -367,7 +367,7 @@ object CollectionCSVManager extends CollectionInputFileReader  {
     val hierarchyChildNodesMetadata = if(mode.equals(CollectionTOCConstants.CREATE)) {
       folderInfoMap.map(record => {
         val nodeInfo = record._2.asInstanceOf[scala.collection.mutable.Map[String, AnyRef]]
-          s""""${record._1}": {"name": "${JsonUtils.serialize(nodeInfo("name").toString)}","root": false,"contentType": "$collectionUnitType", "children": ${if (nodeInfo.contains(CollectionTOCConstants.CHILDREN)) nodeInfo(CollectionTOCConstants.CHILDREN).asInstanceOf[Seq[String]].mkString("[\"", "\",\"", "\"]") else "[]"}}"""
+          s""""${record._1}": {"name": ${JsonUtils.serialize(nodeInfo("name").toString)},"root": false,"contentType": "$collectionUnitType", "children": ${if (nodeInfo.contains(CollectionTOCConstants.CHILDREN)) nodeInfo(CollectionTOCConstants.CHILDREN).asInstanceOf[Seq[String]].mkString("[\"", "\",\"", "\"]") else "[]"}}"""
       }).mkString(",")
     } else {
       val linkedContentsInfoMap: Map[String, Map[String, String]] = if(linkedContentsDetails.nonEmpty) {
@@ -427,7 +427,7 @@ object CollectionCSVManager extends CollectionInputFileReader  {
         {
           val LinkedContentInfo = nodeInfo(CollectionTOCConstants.LINKED_CONTENT).asInstanceOf[Seq[String]].map(contentId => {
             val linkedContentDetails: Map[String, String] = linkedContentsInfoMap(contentId)
-            s""""${linkedContentDetails(CollectionTOCConstants.IDENTIFIER)}": {"name": "${linkedContentDetails(CollectionTOCConstants.NAME)}","root": false,"contentType": "${linkedContentDetails(CollectionTOCConstants.CONTENT_TYPE)}", "children": []}"""
+            s""""${linkedContentDetails(CollectionTOCConstants.IDENTIFIER)}": {"name": ${linkedContentDetails(CollectionTOCConstants.NAME)},"root": false,"contentType": "${linkedContentDetails(CollectionTOCConstants.CONTENT_TYPE)}", "children": []}"""
           }).mkString(",")
           LinkedContentInfo
         } else ""

--- a/content-api/collection-csv-actors/src/main/scala/org.sunbird/collectioncsv/manager/CollectionCSVManager.scala
+++ b/content-api/collection-csv-actors/src/main/scala/org.sunbird/collectioncsv/manager/CollectionCSVManager.scala
@@ -340,7 +340,7 @@ object CollectionCSVManager extends CollectionInputFileReader  {
 
   private def getHierarchyMetadata(folderInfoMap: mutable.LinkedHashMap[String, AnyRef], mode: String, linkedContentsDetails: List[Map[String, AnyRef]], collectionHierarchy: Map[String, AnyRef]): String = {
     val collectionID: String = collectionHierarchy(CollectionTOCConstants.IDENTIFIER).toString
-    val collectionName: String = collectionHierarchy(CollectionTOCConstants.NAME).toString
+    val collectionName: String = JsonUtils.serialize(collectionHierarchy(CollectionTOCConstants.NAME).toString)
     val collectionType: String = collectionHierarchy(CollectionTOCConstants.CONTENT_TYPE).toString
     val collectionUnitType = contentTypeToUnitTypeMapping(collectionType)
     val childrenHierarchy = collectionHierarchy(CollectionTOCConstants.CHILDREN).asInstanceOf[List[Map[String, AnyRef]]]
@@ -367,14 +367,14 @@ object CollectionCSVManager extends CollectionInputFileReader  {
     val hierarchyChildNodesMetadata = if(mode.equals(CollectionTOCConstants.CREATE)) {
       folderInfoMap.map(record => {
         val nodeInfo = record._2.asInstanceOf[scala.collection.mutable.Map[String, AnyRef]]
-          s""""${record._1}": {"name": "${nodeInfo("name").toString}","root": false,"contentType": "$collectionUnitType", "children": ${if (nodeInfo.contains(CollectionTOCConstants.CHILDREN)) nodeInfo(CollectionTOCConstants.CHILDREN).asInstanceOf[Seq[String]].mkString("[\"", "\",\"", "\"]") else "[]"}}"""
+          s""""${record._1}": {"name": "${JsonUtils.serialize(nodeInfo("name").toString)}","root": false,"contentType": "$collectionUnitType", "children": ${if (nodeInfo.contains(CollectionTOCConstants.CHILDREN)) nodeInfo(CollectionTOCConstants.CHILDREN).asInstanceOf[Seq[String]].mkString("[\"", "\",\"", "\"]") else "[]"}}"""
       }).mkString(",")
     } else {
       val linkedContentsInfoMap: Map[String, Map[String, String]] = if(linkedContentsDetails.nonEmpty) {
         linkedContentsDetails.flatMap(linkedContentRecord => {
           Map(linkedContentRecord(CollectionTOCConstants.IDENTIFIER).toString ->
             Map(CollectionTOCConstants.IDENTIFIER -> linkedContentRecord(CollectionTOCConstants.IDENTIFIER).toString,
-              CollectionTOCConstants.NAME -> linkedContentRecord(CollectionTOCConstants.NAME).toString,
+              CollectionTOCConstants.NAME -> JsonUtils.serialize(linkedContentRecord(CollectionTOCConstants.NAME).toString),
               CollectionTOCConstants.CONTENT_TYPE -> linkedContentRecord(CollectionTOCConstants.CONTENT_TYPE).toString))
         }).toMap
       } else Map.empty[String, Map[String, String]]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-26691" title="SB-26691" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-26691</a>  Unable to update the folder  metadata with keywords and description having double quotes.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Name has "\t" character

### Type of change

Please choose appropriate options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran Unit Test
- [X] Ran Manual Test

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

