### PR TITLE
Revert "SB-25735 - Code fix to restrict private content from public read api's"

### DIFF
--- a/assessment-api/assessment-actors/src/main/scala/org/sunbird/managers/AssessmentManager.scala
+++ b/assessment-api/assessment-actors/src/main/scala/org/sunbird/managers/AssessmentManager.scala
@@ -39,12 +39,7 @@ object AssessmentManager {
 		DataNode.read(request).map(node => {
 			val metadata: util.Map[String, AnyRef] = NodeUtil.serialize(node, fields, node.getObjectType.toLowerCase.replace("Image", ""), request.getContext.get("version").asInstanceOf[String])
 			metadata.put("identifier", node.getIdentifier.replace(".img", ""))
-			if(!StringUtils.equalsIgnoreCase(metadata.get("visibility").asInstanceOf[String],"Private")) {
-				ResponseHandler.OK.put(resName, metadata)
-			}
-			else {
-				throw new ClientException("ERR_ACCESS_DENIED", s"$resName visibility is private, hence access denied")
-			}
+			ResponseHandler.OK.put(resName, metadata)
 		})
 	}
 

--- a/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionActorTest.scala
+++ b/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionActorTest.scala
@@ -1,11 +1,11 @@
 package org.sunbird.actors
 import java.util
+
 import akka.actor.Props
 import org.scalamock.scalatest.MockFactory
 import org.sunbird.common.HttpUtil
 import org.sunbird.common.dto.ResponseHandler
 import org.sunbird.common.dto.{Property, Request, Response}
-import org.sunbird.common.exception.ResponseCode
 import org.sunbird.graph.dac.model.{Node, SearchCriteria}
 import org.sunbird.graph.utils.ScalaJsonUtils
 import org.sunbird.graph.{GraphService, OntologyEngineContext}
@@ -53,25 +53,6 @@ class QuestionActorTest extends BaseSpec with MockFactory {
 		request.setOperation("readQuestion")
 		val response = callActor(request, Props(new QuestionActor()))
 		assert("successful".equals(response.getParams.getStatus))
-	}
-
-	it should "return client error response for 'readQuestion' if visibility is 'Private'" in {
-		implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
-		val graphDB = mock[GraphService]
-		(oec.graphService _).expects().returns(graphDB)
-		val node = getNode("Question", Some(new util.HashMap[String, AnyRef]() {
-			{
-				put("name", "Question")
-				put("visibility","Private")
-			}
-		}))
-		(graphDB.getNodeByUniqueId(_: String, _: String, _: Boolean, _: Request)).expects(*, *, *, *).returns(Future(node))
-		val request = getQuestionRequest()
-		request.getContext.put("identifier", "do1234")
-		request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
-		request.setOperation("readQuestion")
-		val response = callActor(request, Props(new QuestionActor()))
-		assert(response.getResponseCode == ResponseCode.CLIENT_ERROR)
 	}
 
 	it should "return success response for 'updateQuestion'" in {

--- a/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionSetActorTest.scala
+++ b/assessment-api/assessment-actors/src/test/scala/org/sunbird/actors/QuestionSetActorTest.scala
@@ -1,21 +1,22 @@
 package org.sunbird.actors
 
+import java.util
+
 import akka.actor.Props
 import org.scalamock.scalatest.MockFactory
 import org.sunbird.common.HttpUtil
-import org.sunbird.common.dto.{Request, Response, ResponseHandler}
-import org.sunbird.common.exception.ResponseCode
-import org.sunbird.graph.dac.model.{Node, SearchCriteria}
+import org.sunbird.common.dto.{Property, Request, Response, ResponseHandler}
+import org.sunbird.graph.dac.model.{Node, Relation, SearchCriteria}
+import org.sunbird.graph.nodes.DataNode.getRelationMap
 import org.sunbird.graph.utils.ScalaJsonUtils
 import org.sunbird.graph.{GraphService, OntologyEngineContext}
 import org.sunbird.kafka.client.KafkaClient
 import org.sunbird.utils.JavaJsonUtils
 
-import java.util
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class QuestionSetActorTest extends BaseSpec with MockFactory {
 
@@ -71,26 +72,6 @@ class QuestionSetActorTest extends BaseSpec with MockFactory {
         request.setOperation("readQuestionSet")
         val response = callActor(request, Props(new QuestionSetActor()))
         assert("successful".equals(response.getParams.getStatus))
-    }
-
-    it should "return client error response for 'readQuestionSet' if visibility is 'Private'" in {
-        implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
-        val graphDB = mock[GraphService]
-        (oec.graphService _).expects().returns(graphDB).anyNumberOfTimes()
-        val node = getNode("QuestionSet", Some(new util.HashMap[String, AnyRef]() {
-            {
-                put("name", "QuestionSet")
-                put("description", "Updated question Set")
-                put("visibility","Private")
-            }
-        }))
-        (graphDB.getNodeByUniqueId(_: String, _: String, _: Boolean, _: Request)).expects(*, *, *, *).returns(Future(node))
-        val request = getQuestionSetRequest()
-        request.getContext.put("identifier", "do1234")
-        request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
-        request.setOperation("readQuestionSet")
-        val response = callActor(request, Props(new QuestionSetActor()))
-        assert(response.getResponseCode == ResponseCode.CLIENT_ERROR)
     }
 
     it should "return success response for 'updateQuestionSet'" in {

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ContentActor.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ContentActor.scala
@@ -79,12 +79,7 @@ class ContentActor @Inject() (implicit oec: OntologyEngineContext, ss: StorageSe
       else {
         response.put(responseSchemaName, metadata)
       }
-			if(!StringUtils.equalsIgnoreCase(metadata.get("visibility").asInstanceOf[String],"Private")) {
-				response
-			}
-			else {
-				throw new ClientException("ERR_ACCESS_DENIED", "content visibility is private, hence access denied")
-			}
+			response
 		})
 	}
 

--- a/content-api/content-actors/src/test/scala/org/sunbird/content/actors/TestContentActor.scala
+++ b/content-api/content-actors/src/test/scala/org/sunbird/content/actors/TestContentActor.scala
@@ -246,26 +246,6 @@ class TestContentActor extends BaseSpec with MockFactory {
         assert("successful".equals(response.getParams.getStatus))
     }
 
-    it should "return client error response for 'readContent' if visibility is 'Private" in {
-        implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
-        val graphDB = mock[GraphService]
-        (oec.graphService _).expects().returns(graphDB)
-        val node = getNode("Content", Some(new util.HashMap[String, AnyRef]() {
-            {
-                put("name", "Content")
-                put("visibility","Private")
-            }
-        }))
-        (graphDB.getNodeByUniqueId(_: String, _: String, _: Boolean, _: Request)).expects(*, *, *, *).returns(Future(node))
-        implicit val ss = mock[StorageService]
-        val request = getContentRequest()
-        request.getContext.put("identifier","do1234")
-        request.putAll(mapAsJavaMap(Map("identifier" -> "do_1234", "fields" -> "")))
-        request.setOperation("readContent")
-        val response = callActor(request, Props(new ContentActor()))
-        assert(response.getResponseCode == ResponseCode.CLIENT_ERROR)
-    }
-
     it should "return success response for 'updateContent'" in {
         implicit val oec: OntologyEngineContext = mock[OntologyEngineContext]
         val graphDB = mock[GraphService]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-25735" title="SB-25735" target="_blank"><img alt="Epic" src="https://project-sunbird.atlassian.net/images/icons/issuetypes/epic.svg" />SB-25735</a>  Content Visibility - Allowing Creation, editing, and accessing(active/live content) of Private resource content on Diksha
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Reverts project-sunbird/knowledge-platform#717