### PR TITLE
Issue #SB-27002 fix: prevStatus missing on rejectContent

### DIFF
--- a/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ContentActor.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ContentActor.scala
@@ -256,9 +256,13 @@ class ContentActor @Inject() (implicit oec: OntologyEngineContext, ss: StorageSe
 				throw new ClientException("ERR_METADATA_ISSUE", "Content metadata error, status is blank for identifier:" + node.getIdentifier)
       if (StringUtils.equals("Review", status)) {
         request.getRequest.put("status", "Draft")
-      } else if (StringUtils.equals("FlagReview", status))
+				request.getRequest.put("prevStatus", "Review")
+      } else if (StringUtils.equals("FlagReview", status)) {
         request.getRequest.put("status", "FlagDraft")
+				request.getRequest.put("prevStatus", "FlagReview")
+			}
       else new ClientException("ERR_INVALID_REQUEST", "Content not in Review status.")
+
 			request.getRequest.put("versionKey", node.getMetadata.get("versionKey"))
 			request.putIn("publishChecklist", null).putIn("publishComment", null)
       //updating node after changing the status


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-27002" title="SB-27002" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-27002</a>  Creator  is not able to see the comment added by reviewer while reject the course.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Issue #SB-27002 fix: prevStatus missing on rejectContent

### Type of change

Please choose appropriate options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran Unit Test

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

