### PR TITLE
SB-25735 - Fix - To update the questionset visibility to 'Private' through updateHierarchy

### DIFF
--- a/assessment-api/assessment-service/conf/application.conf
+++ b/assessment-api/assessment-service/conf/application.conf
@@ -419,3 +419,5 @@ import {
     questionset = []
   }
 }
+
+root_node_visibility=["Default","Private"]

--- a/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
+++ b/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
@@ -100,7 +100,7 @@ object UpdateHierarchyManager {
                 TelemetryManager.error("UpdateHierarchyManager.getValidatedRootNode :: Invalid MimeType for Root node id: " + identifier)
                 throw new ClientException(HierarchyErrorCodes.ERR_INVALID_ROOT_ID, "Invalid MimeType for Root Node Identifier  : " + identifier)
             }
-            if(!CollectionUtils.containsAny(HierarchyConstants.ROOT_NODE_VISIBILITY, metadata.getOrDefault(HierarchyConstants.VISIBILITY, "").asInstanceOf[String])) {
+            if(!CollectionUtils.containsAny(Platform.getStringList("root_node_visibility", List("Default").asJava), metadata.getOrDefault(HierarchyConstants.VISIBILITY, "").asInstanceOf[String])) {
                 TelemetryManager.error("UpdateHierarchyManager.getValidatedRootNode :: Invalid Visibility found for Root node id: " + identifier)
                 throw new ClientException(HierarchyErrorCodes.ERR_INVALID_ROOT_ID, "Invalid Visibility found for Root Node Identifier  : " + identifier)
             }

--- a/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
+++ b/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
@@ -100,6 +100,10 @@ object UpdateHierarchyManager {
                 TelemetryManager.error("UpdateHierarchyManager.getValidatedRootNode :: Invalid MimeType for Root node id: " + identifier)
                 throw new ClientException(HierarchyErrorCodes.ERR_INVALID_ROOT_ID, "Invalid MimeType for Root Node Identifier  : " + identifier)
             }
+            if(!CollectionUtils.containsAny(HierarchyConstants.ROOT_NODE_VISIBILITY, metadata.getOrDefault(HierarchyConstants.VISIBILITY, "").asInstanceOf[String])) {
+                TelemetryManager.error("UpdateHierarchyManager.getValidatedRootNode :: Invalid Visibility found for Root node id: " + identifier)
+                throw new ClientException(HierarchyErrorCodes.ERR_INVALID_ROOT_ID, "Invalid Visibility found for Root Node Identifier  : " + identifier)
+            }
             rootNode.setObjectType(HierarchyConstants.QUESTIONSET_OBJECT_TYPE)
             rootNode.getMetadata.put(HierarchyConstants.OBJECT_TYPE, HierarchyConstants.QUESTIONSET_OBJECT_TYPE)
             rootNode

--- a/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
+++ b/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
@@ -100,10 +100,6 @@ object UpdateHierarchyManager {
                 TelemetryManager.error("UpdateHierarchyManager.getValidatedRootNode :: Invalid MimeType for Root node id: " + identifier)
                 throw new ClientException(HierarchyErrorCodes.ERR_INVALID_ROOT_ID, "Invalid MimeType for Root Node Identifier  : " + identifier)
             }
-            if(!StringUtils.equals(metadata.getOrDefault(HierarchyConstants.VISIBILITY, "").asInstanceOf[String], HierarchyConstants.DEFAULT)) {
-                TelemetryManager.error("UpdateHierarchyManager.getValidatedRootNode :: Invalid Visibility found for Root node id: " + identifier)
-                throw new ClientException(HierarchyErrorCodes.ERR_INVALID_ROOT_ID, "Invalid Visibility found for Root Node Identifier  : " + identifier)
-            }
             rootNode.setObjectType(HierarchyConstants.QUESTIONSET_OBJECT_TYPE)
             rootNode.getMetadata.put(HierarchyConstants.OBJECT_TYPE, HierarchyConstants.QUESTIONSET_OBJECT_TYPE)
             rootNode

--- a/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/utils/HierarchyConstants.scala
+++ b/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/utils/HierarchyConstants.scala
@@ -51,5 +51,4 @@ object HierarchyConstants {
     val QUESTIONSET_MIME_TYPE: String = "application/vnd.sunbird.questionset"
 	val QUESTIONSET_OBJECT_TYPE: String = "QuestionSet"
     val OPERATION_UPDATE_HIERARCHY: String = "updateHierarchy"
-    val ROOT_NODE_VISIBILITY: List[String] = List("Default", "Private")
 }

--- a/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/utils/HierarchyConstants.scala
+++ b/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/utils/HierarchyConstants.scala
@@ -51,4 +51,5 @@ object HierarchyConstants {
     val QUESTIONSET_MIME_TYPE: String = "application/vnd.sunbird.questionset"
 	val QUESTIONSET_OBJECT_TYPE: String = "QuestionSet"
     val OPERATION_UPDATE_HIERARCHY: String = "updateHierarchy"
+    val ROOT_NODE_VISIBILITY: List[String] = List("Default", "Private")
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-25735" title="SB-25735" target="_blank"><img alt="Epic" src="https://project-sunbird.atlassian.net/images/icons/issuetypes/epic.svg" />SB-25735</a>  Content Visibility - Allowing Creation, editing, and accessing(active/live content) of Private resource content on Diksha
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

