### PR TITLE
Issue #SB-26381 feat: Added the accessibility field in content schema.

### DIFF
--- a/schemas/collection/1.0/schema.json
+++ b/schemas/collection/1.0/schema.json
@@ -1280,6 +1280,12 @@
         "No"
       ],
       "default": "No"
+    },
+    "accessibility": {
+      "type": "array",
+      "items": {
+          "type": "object"
+      }
     }
   }
 }

--- a/schemas/content/1.0/schema.json
+++ b/schemas/content/1.0/schema.json
@@ -1389,6 +1389,12 @@
             "items": {
               "type": "object"
             }
+        },
+        "accessibility": {
+          "type": "array",
+          "items": {
+              "type": "object"
+          }
         }
     }
 }

--- a/schemas/question/1.0/schema.json
+++ b/schemas/question/1.0/schema.json
@@ -548,6 +548,12 @@
     },
     "rejectComment": {
       "type": "string"
+    },
+    "accessibility": {
+      "type": "array",
+      "items": {
+          "type": "object"
+      }
     }
   },
   "additionalProperties": false

--- a/schemas/questionset/1.0/schema.json
+++ b/schemas/questionset/1.0/schema.json
@@ -586,6 +586,12 @@
     },
     "rejectComment": {
       "type": "string"
+    },
+    "accessibility": {
+      "type": "array",
+      "items": {
+          "type": "object"
+      }
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-26381" title="SB-26381" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SB-26381</a>  Enable storing of accessibility information of an asset
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

