### PR TITLE
Issue #SB-15501 feat: Fixed API version and name.

### DIFF
--- a/content-api/content-service/app/controllers/v4/AssetController.scala
+++ b/content-api/content-service/app/controllers/v4/AssetController.scala
@@ -90,7 +90,7 @@ class AssetController  @Inject()(@Named(ActorNames.CONTENT_ACTOR) contentActor: 
         content.putAll(Map("identifier" -> identifier, "type" -> `type`.getOrElse("assets")).asJava)
         val contentRequest = getRequest(content, headers, "uploadPreSignedUrl")
         setRequestContext(contentRequest, version, objectType, schemaName)
-        getResult(ApiId.UPLOAD_PRE_SIGNED_ASSET, contentActor, contentRequest)
+        getResult(ApiId.UPLOAD_PRE_SIGNED_ASSET, contentActor, contentRequest, version = apiVersion)
     }
 
     def copy(identifier: String) = Action.async { implicit request =>

--- a/content-api/content-service/app/controllers/v4/CollectionController.scala
+++ b/content-api/content-service/app/controllers/v4/CollectionController.scala
@@ -90,7 +90,7 @@ class CollectionController  @Inject()(@Named(ActorNames.CONTENT_ACTOR) contentAc
         val contentRequest = getRequest(body, headers, "addHierarchy")
         contentRequest.put("mode", "edit")
         setRequestContext(contentRequest, version, objectType, schemaName)
-        getResult(ApiId.ADD_HIERARCHY_V4, collectionActor, contentRequest)
+        getResult(ApiId.ADD_HIERARCHY_V4, collectionActor, contentRequest, version = apiVersion)
     }
 
     def removeHierarchy() = Action.async { implicit request =>
@@ -251,7 +251,7 @@ class CollectionController  @Inject()(@Named(ActorNames.CONTENT_ACTOR) contentAc
         val contentRequest = getRequest(content, headers, "reviewContent")
         setRequestContext(contentRequest, version, objectType, schemaName)
         contentRequest.getContext.put("identifier", identifier);
-        getResult(ApiId.REVIEW_COLLECTION, contentActor, contentRequest)
+        getResult(ApiId.REVIEW_COLLECTION, contentActor, contentRequest, version = apiVersion)
     }
 
 

--- a/content-api/content-service/app/controllers/v4/ContentController.scala
+++ b/content-api/content-service/app/controllers/v4/ContentController.scala
@@ -33,7 +33,7 @@ class ContentController @Inject()(@Named(ActorNames.CONTENT_ACTOR) contentActor:
         else {
             val contentRequest = getRequest(content, headers, "createContent", true)
             setRequestContext(contentRequest, version, objectType, schemaName)
-            getResult(ApiId.CREATE_ASSET, contentActor, contentRequest, version = apiVersion)
+            getResult(ApiId.CREATE_CONTENT, contentActor, contentRequest, version = apiVersion)
         }
     }
 
@@ -97,7 +97,7 @@ class ContentController @Inject()(@Named(ActorNames.CONTENT_ACTOR) contentActor:
         content.putAll(Map("identifier" -> identifier).asJava)
         val acceptRequest = getRequest(content, headers, "acceptFlag")
         setRequestContext(acceptRequest, version, objectType, schemaName)
-        getResult(ApiId.ACCEPT_FLAG, contentActor, acceptRequest)
+        getResult(ApiId.ACCEPT_FLAG, contentActor, acceptRequest, version = apiVersion)
     }
 
 
@@ -108,7 +108,7 @@ class ContentController @Inject()(@Named(ActorNames.CONTENT_ACTOR) contentActor:
         content.putAll(Map("identifier" -> identifier).asJava)
         val discardRequest = getRequest(content, headers, "discardContent")
         setRequestContext(discardRequest, version, objectType, schemaName)
-        getResult(ApiId.DISCARD_CONTENT, contentActor, discardRequest)
+        getResult(ApiId.DISCARD_CONTENT, contentActor, discardRequest, version = apiVersion)
     }
     def retire(identifier: String) = Action.async { implicit request =>
         val headers = commonHeaders()
@@ -192,7 +192,7 @@ class ContentController @Inject()(@Named(ActorNames.CONTENT_ACTOR) contentActor:
         val contentRequest = getRequest(content, headers, "reviewContent")
         setRequestContext(contentRequest, version, objectType, schemaName)
         contentRequest.getContext.put("identifier", identifier);
-        getResult(ApiId.REVIEW_CONTENT, contentActor, contentRequest)
+        getResult(ApiId.REVIEW_CONTENT, contentActor, contentRequest, version = apiVersion)
     }
 
     def reviewReject(identifier: String) = Action.async { implicit request =>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-15501" title="SB-15501" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-15501</a>  [Telemetry]:   In SHARE-in event, telemetry data  should capture if entire Textbook downloaded or individual content downloaded
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran unit test

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

