### PR TITLE
Issue #SB-28951 fix: code changes to handle bulk update

### DIFF
--- a/assessment-api/assessment-actors/src/main/scala/org/sunbird/managers/AssessmentManager.scala
+++ b/assessment-api/assessment-actors/src/main/scala/org/sunbird/managers/AssessmentManager.scala
@@ -169,25 +169,27 @@ object AssessmentManager {
 	}
 
 	def updateHierarchy(hierarchyString: String, status: String, rootUserId: String): (java.util.Map[String, AnyRef], java.util.List[String]) = {
-		val hierarchy = if (!hierarchyString.asInstanceOf[String].isEmpty) {
+		val hierarchy: java.util.Map[String, AnyRef] = if (!hierarchyString.asInstanceOf[String].isEmpty) {
 			JsonUtils.deserialize(hierarchyString.asInstanceOf[String], classOf[java.util.Map[String, AnyRef]])
 		} else
 			new java.util.HashMap[String, AnyRef]()
+		val keys = List("identifier", "children").asJava
+		hierarchy.keySet().retainAll(keys)
 		val children = hierarchy.getOrDefault("children", new util.ArrayList[java.util.Map[String, AnyRef]]).asInstanceOf[util.List[java.util.Map[String, AnyRef]]]
-		hierarchy.put("status", status)
 		val childrenToUpdate: List[String] = updateChildrenRecursive(children, status, List(), rootUserId)
 		(hierarchy, childrenToUpdate.asJava)
 	}
 
 	private def updateChildrenRecursive(children: util.List[util.Map[String, AnyRef]], status: String, idList: List[String], rootUserId: String): List[String] = {
 		children.toList.flatMap(content => {
+			val objectType = content.getOrDefault("objectType", "").asInstanceOf[String]
 			val updatedIdList: List[String] =
-				if (StringUtils.equalsAnyIgnoreCase(content.getOrDefault("visibility", "").asInstanceOf[String], "Parent") || (StringUtils.equalsAnyIgnoreCase(content.getOrDefault("visibility", "").asInstanceOf[String], "Default") && validStatus.contains(content.getOrDefault("status", "").asInstanceOf[String]) && StringUtils.equals(rootUserId, content.getOrDefault("createdBy", "").asInstanceOf[String]))) {
+				if (StringUtils.equalsAnyIgnoreCase(content.getOrDefault("visibility", "").asInstanceOf[String], "Parent") || (StringUtils.equalsIgnoreCase( objectType, "Question") && StringUtils.equalsAnyIgnoreCase(content.getOrDefault("visibility", "").asInstanceOf[String], "Default") && validStatus.contains(content.getOrDefault("status", "").asInstanceOf[String]) && StringUtils.equals(rootUserId, content.getOrDefault("createdBy", "").asInstanceOf[String]))) {
 					content.put("lastStatusChangedOn", DateUtils.formatCurrentDate)
+					content.put("prevStatus", content.getOrDefault("status", "Draft"))
 					content.put("status", status)
-					content.put("prevStatus", "Draft")
 					content.put("lastUpdatedOn", DateUtils.formatCurrentDate)
-					content.get("identifier").asInstanceOf[String] :: idList
+					if(StringUtils.equalsAnyIgnoreCase(objectType, "Question")) content.get("identifier").asInstanceOf[String] :: idList else idList
 				} else idList
 			val list = updateChildrenRecursive(content.getOrDefault("children", new util.ArrayList[Map[String, AnyRef]]).asInstanceOf[util.List[util.Map[String, AnyRef]]], status, updatedIdList, rootUserId)
 			list ++ updatedIdList


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-28951" title="SB-28951" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />SB-28951</a>  Question set publish throwing error while adding live questions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

