### PR TITLE
Issue #SB-29808 debug: Review API failing

### DIFF
--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/ecml/processor/LocalizeAssetProcessor.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/ecml/processor/LocalizeAssetProcessor.scala
@@ -62,15 +62,16 @@ trait LocalizeAssetProcessor extends IProcessor {
 	}
 
 	def downloadFile(downloadPath: String, fileUrl: String): File = try {
-		TelemetryManager.info("LocalizeAssetProcessor:: downloadFile:: downloadPath:: " + downloadPath)
 		TelemetryManager.info("LocalizeAssetProcessor:: downloadFile:: fileUrl:: " + fileUrl)
 		createDirectory(downloadPath)
 		val file = new File(downloadPath + File.separator + getFileNameFromURL(fileUrl))
 		FileUtils.copyURLToFile(new URL(fileUrl), file)
 		file
 	} catch {
-		case e: IOException =>
+		case e: IOException => {
+			TelemetryManager.info("LocalizeAssetProcessor:: downloadFile:: IOException:: " + e.getMessage)
 			throw new ClientException("ERR_INVALID_FILE_URL", "Please Provide Valid File Url!")
+		}
 	}
 
 	def createDirectory(directoryName: String): Unit = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-29808" title="SB-29808" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-29808</a>  Course Assessment and h5p content is not getting publsihed from Dock staging to sunbird Staging 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran Unit Tests

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

