### PR TITLE
Issue #SB-29808 debug: Review API failing for H5P contents

### DIFF
--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManager.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManager.scala
@@ -21,7 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class BaseMimeTypeManager(implicit ss: StorageService) {
 
-	protected val TEMP_FILE_LOCATION = Platform.getString("content.upload.temp_location", "/tmp/content")
+	protected val TEMP_FILE_LOCATION: String = Platform.getString("content.upload.temp_location", "/tmp/content")
 	private val CONTENT_FOLDER = "cloud_storage.content.folder"
 	private val ARTIFACT_FOLDER = "cloud_storage.artifact.folder"
 	private val validator = new UrlValidator()
@@ -51,10 +51,11 @@ class BaseMimeTypeManager(implicit ss: StorageService) {
 			throw new ClientException("ERR_INVALID_NODE", "Please Provide Valid Node!")
 		if (null == data)
 			throw new ClientException("ERR_INVALID_DATA", "Please Provide Valid File Or File Url!")
-		if (data.isInstanceOf[String])
-			validateUrl(data.toString)
-		else if (data.isInstanceOf[File])
-			validateFile(data.asInstanceOf[File])
+		data match {
+			case _: String => validateUrl(data.toString)
+			case file: File => validateFile(file)
+			case _ =>
+		}
 	}
 
 	def validateFile(file: File): Unit = {
@@ -102,7 +103,7 @@ class BaseMimeTypeManager(implicit ss: StorageService) {
 
 	def getFileNameFromURL(fileUrl: String): String = {
 		var fileName = FilenameUtils.getBaseName(fileUrl) + "_" + System.currentTimeMillis
-		if (!FilenameUtils.getExtension(fileUrl).isEmpty) fileName += "." + FilenameUtils.getExtension(fileUrl)
+		if (FilenameUtils.getExtension(fileUrl).nonEmpty) fileName += "." + FilenameUtils.getExtension(fileUrl)
 		fileName
 	}
 
@@ -114,12 +115,13 @@ class BaseMimeTypeManager(implicit ss: StorageService) {
 		if (null != file && file.exists()) {
 			val zipFile: ZipFile = new ZipFile(file)
 			try {
-				val entries = checkParams
-					.filter(fileName => null != zipFile.getEntry(fileName))
-				null != entries && !entries.isEmpty
+				val entries = checkParams.filter(fileName => null != zipFile.getEntry(fileName))
+				null != entries && entries.nonEmpty
 			}
 			catch {
-				case e: Exception => throw new ClientException("ERR_INVALID_FILE", "Please Provide Valid File!")
+				case e: Exception =>
+					TelemetryManager.error("Error while verifying zip file: ", e)
+					throw new ClientException("ERR_INVALID_FILE", "Please Provide Valid File!")
 			} finally {
 				if (null != zipFile) zipFile.close()
 			}

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/H5PMimeTypeMgrImpl.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/H5PMimeTypeMgrImpl.scala
@@ -19,8 +19,13 @@ class H5PMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeManage
 
     override def upload(objectId: String, node: Node, uploadFile: File, filePath: Option[String], params: UploadParams)(implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
         validateUploadRequest(objectId, node, uploadFile)
+        TelemetryManager.info("H5P content upload params:: " + params)
         val validationParams = if (StringUtils.equalsIgnoreCase(params.fileFormat.getOrElse(""), COMPOSED_H5P_ZIP))
             List[String]("/content/h5p.json", "content/h5p.json") else List[String]("h5p.json", "/h5p.json")
+
+        TelemetryManager.info("H5P content uploadFile exists:: " + uploadFile.exists())
+        TelemetryManager.info("H5P content validationParams:: " + validationParams)
+
         if (isValidPackageStructure(uploadFile, validationParams)) {
             val extractionBasePath = getBasePath(objectId)
             val zipFile = if (!StringUtils.equalsIgnoreCase(params.fileFormat.getOrElse(""), COMPOSED_H5P_ZIP)) {
@@ -41,7 +46,7 @@ class H5PMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeManage
             }
             Future { Map[String, AnyRef]("identifier" -> objectId, "artifactUrl" -> urls(IDX_S3_URL), "size" -> getFileSize(uploadFile).asInstanceOf[AnyRef], "s3Key" -> urls(IDX_S3_KEY)) }
         } else {
-            TelemetryManager.error("ERR_INVALID_FILE" + "Please Provide Valid File! with file name: " + uploadFile.getName)
+            TelemetryManager.error("ERR_INVALID_FILE:: " + "Please Provide Valid File! with file name: " + uploadFile.getName)
             throw new ClientException("ERR_INVALID_FILE", "Please Provide Valid File!")
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-29808" title="SB-29808" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-29808</a>  Course Assessment and h5p content is not getting publsihed from Dock staging to sunbird Staging 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran Unit Tests

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

