### PR TITLE
Issue #CO-173 debug: Adding debug statements

### DIFF
--- a/ontology-engine/graph-core_2.11/src/main/scala/org/sunbird/graph/GraphService.scala
+++ b/ontology-engine/graph-core_2.11/src/main/scala/org/sunbird/graph/GraphService.scala
@@ -2,6 +2,7 @@ package org.sunbird.graph
 
 import org.sunbird.common.Platform
 import org.sunbird.common.dto.{Property, Request, Response, ResponseHandler}
+import org.sunbird.common.exception.ResponseCode
 import org.sunbird.graph.dac.model.{Node, SearchCriteria}
 import org.sunbird.graph.external.ExternalPropsManager
 import org.sunbird.graph.service.operation.{GraphAsyncOperations, Neo4JBoltSearchOperations, NodeAsyncOperations, SearchAsyncOperations}
@@ -57,7 +58,7 @@ class GraphService {
     def readExternalProps(request: Request, fields: List[String]): Future[Response] = {
         ExternalPropsManager.fetchProps(request, fields).map(res => {
             println("GraphService:: readExternalProps:: res.params:: " + res.getParams+ " || res.responseCode:: " + res.getResponseCode + " || res.result:: " + res.getResult)
-            if(isrRelativePathEnabled) {
+            if(isrRelativePathEnabled && res.getResponseCode != ResponseCode.RESOURCE_NOT_FOUND) {
                 val updatedResult = CSPMetaUtil.updateExternalAbsolutePath(res.getResult)
                 val response = ResponseHandler.OK()
                 response.putAll(updatedResult)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/CO-173" title="CO-173" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />CO-173</a>  Transcript file (.vtt) is not saving while adding the transcript file in Cokreat Portal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

