### PR TITLE
Issue #KN-751 fix: Content and collection image publish issue

### DIFF
--- a/content-api/content-actors/src/main/scala/org/sunbird/content/publish/mgr/PublishManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/publish/mgr/PublishManager.scala
@@ -78,7 +78,7 @@ object PublishManager {
 		}
 
 		//objectData
-		objectData.put(ContentConstants.ID, identifier)
+		objectData.put(ContentConstants.ID, identifier.replace(".img",""))
 		objectData.put(ContentConstants.VER, metadata.get(ContentConstants.VERSION_KEY))
 
 		//edata
@@ -91,7 +91,7 @@ object PublishManager {
 		instructionEventMetadata.put(ContentConstants.PACKAGE_VERSION, metadata.getOrDefault(ContentConstants.PACKAGE_VERSION,0.asInstanceOf[AnyRef]))
 		instructionEventMetadata.put(ContentConstants.MIME_TYPE, metadata.get(ContentConstants.MIME_TYPE))
 		instructionEventMetadata.put(ContentConstants.LAST_PUBLISHED_BY, metadata.get(ContentConstants.LAST_PUBLISHED_BY))
-		instructionEventMetadata.put(ContentConstants.IDENTIFIER, identifier)
+		instructionEventMetadata.put(ContentConstants.IDENTIFIER, identifier.replace(".img",""))
 		instructionEventMetadata.put(ContentConstants.OBJECT_TYPE, objectType)
 		edata.put(ContentConstants.METADATA, instructionEventMetadata)
 		edata.put(ContentConstants.ACTION, ContentConstants.PUBLISH)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/KN-751" title="KN-751" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />KN-751</a>  CLONE - Two live books are getting displayed on the workspace after republish of the live version of the textbook.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

