### PR TITLE
Update Kafka client version to 3.7.1

### DIFF
--- a/platform-core/kafka-client/pom.xml
+++ b/platform-core/kafka-client/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>kafka-client</artifactId>
 
     <properties>
-        <kafka.client.version>1.1.0</kafka.client.version>
+        <kafka.client.version>3.7.1</kafka.client.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

This PR upgrades the Kafka client library to version **3.7.1** to ensure compatibility with **Kafka 4.0.0**.
