### PR TITLE
ci(workflows): allow repo var override for Service build

### DIFF
--- a/.github/workflows/content-service.yml
+++ b/.github/workflows/content-service.yml
@@ -13,11 +13,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Check if build is enabled
         id: check
+        env:
+          BUILD_ENABLED_VAR: ${{ vars.CONTENT_SERVICE_BUILD_ENABLED }}
         run: |
-          ENABLED=$(cat .github/build-config.json | jq -r '.services.content_service')
+          if [ -n "$BUILD_ENABLED_VAR" ]; then
+            ENABLED="$BUILD_ENABLED_VAR"
+            echo "Taking value from CONTENT_SERVICE_BUILD_ENABLED: $ENABLED"
+          else
+            ENABLED=$(cat .github/build-config.json | jq -r '.services.content_service')
+            echo "Taking value from build-config.json: $ENABLED"
+          fi
           echo "enabled=$ENABLED" >> $GITHUB_OUTPUT
           echo "Content Service build enabled: $ENABLED"
 
@@ -68,7 +76,7 @@ jobs:
             -DCLOUD_STORE_ARTIFACT_ID=${{ vars.CLOUD_STORE_ARTIFACT_ID }} \
             -DCLOUD_STORE_VERSION=${{ vars.CLOUD_STORE_VERSION }}
 
-      # Step 6: Build Docker image 
+      # Step 6: Build Docker image
       - name: Build Docker Image
         run: |
           IMAGE_NAME="content-service"
@@ -77,7 +85,7 @@ jobs:
 
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
-     
+
       # Step 7: Push Docker Image
       - name: Push Docker Image
         run: |

--- a/.github/workflows/knowlg-service.yml
+++ b/.github/workflows/knowlg-service.yml
@@ -13,11 +13,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Check if build is enabled
         id: check
+        env:
+          BUILD_ENABLED_VAR: ${{ vars.KNOWLG_SERVICE_BUILD_ENABLED }}
         run: |
-          ENABLED=$(cat .github/build-config.json | jq -r '.services.knowlg_service')
+          if [ -n "$BUILD_ENABLED_VAR" ]; then
+            ENABLED="$BUILD_ENABLED_VAR"
+             echo "Taking value from KNOWLG_SERVICE_BUILD_ENABLED: $ENABLED"
+          else
+            ENABLED=$(cat .github/build-config.json | jq -r '.services.knowlg_service')
+             echo "Taking value from build-config.json: $ENABLED"
+          fi
           echo "enabled=$ENABLED" >> $GITHUB_OUTPUT
           echo "Knowlg Service build enabled: $ENABLED"
 
@@ -82,3 +90,4 @@ jobs:
         run: |
           docker push $REGISTRY_URL/${IMAGE_NAME}:${IMAGE_TAG}
           echo "Pushed Docker image: $REGISTRY_URL/${IMAGE_NAME}:${IMAGE_TAG}"
+          

--- a/.github/workflows/search-service.yml
+++ b/.github/workflows/search-service.yml
@@ -13,11 +13,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Check if build is enabled
         id: check
+        env:
+          BUILD_ENABLED_VAR: ${{ vars.SEARCH_SERVICE_BUILD_ENABLED }}
         run: |
-          ENABLED=$(cat .github/build-config.json | jq -r '.services.search_service')
+          if [ -n "$BUILD_ENABLED_VAR" ]; then
+            ENABLED="$BUILD_ENABLED_VAR"
+            echo "Taking value from SEARCH_SERVICE_BUILD_ENABLED: $ENABLED"
+          else
+            ENABLED=$(cat .github/build-config.json | jq -r '.services.search_service')
+            echo "Taking value from build-config.json: $ENABLED"
+          fi
           echo "enabled=$ENABLED" >> $GITHUB_OUTPUT
           echo "Search Service build enabled: $ENABLED"
 

--- a/.github/workflows/taxonomy-service.yml
+++ b/.github/workflows/taxonomy-service.yml
@@ -13,11 +13,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Check if build is enabled
         id: check
+        env:
+          BUILD_ENABLED_VAR: ${{ vars.TAXONOMY_SERVICE_BUILD_ENABLED }}
         run: |
-          ENABLED=$(cat .github/build-config.json | jq -r '.services.taxonomy_service')
+          if [ -n "$BUILD_ENABLED_VAR" ]; then
+            ENABLED="$BUILD_ENABLED_VAR"
+            echo "Taking value from TAXONOMY_SERVICE_BUILD_ENABLED: $ENABLED"
+          else
+            ENABLED=$(cat .github/build-config.json | jq -r '.services.taxonomy_service')
+            echo "Taking value from build-config.json: $ENABLED"
+          fi
           echo "enabled=$ENABLED" >> $GITHUB_OUTPUT
           echo "Taxonomy Service build enabled: $ENABLED"
 
@@ -39,7 +47,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
 
-       # Step 3: Set up Login to Docker registry
+        # Step 3: Set up Login to Docker registry
       - name: Registry Login
         uses: ./.github/actions/registry-login
         with:


### PR DESCRIPTION
## Summary

Prefer the repository variable SERVICE_BUILD_ENABLED over build-config.json to toggle the Service build.