### PR TITLE
refactor: remove redundant and duplicate import statements

### DIFF
--- a/assessment-api/assessment-actors/src/main/scala/org/sunbird/v5/actors/QuestionActor.scala
+++ b/assessment-api/assessment-actors/src/main/scala/org/sunbird/v5/actors/QuestionActor.scala
@@ -17,7 +17,6 @@ import org.sunbird.v5.managers.AssessmentV5Manager
 
 import java.util
 import javax.inject.Inject
-import scala.collection.JavaConverters
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/assessment-api/assessment-actors/src/main/scala/org/sunbird/v5/actors/QuestionSetActor.scala
+++ b/assessment-api/assessment-actors/src/main/scala/org/sunbird/v5/actors/QuestionSetActor.scala
@@ -21,7 +21,6 @@ import org.sunbird.v5.managers.AssessmentV5Manager
 
 import java.util
 import javax.inject.Inject
-import scala.collection.JavaConverters
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/taxonomy-api/taxonomy-actors/src/main/scala/org/sunbird/actors/LockActor.scala
+++ b/taxonomy-api/taxonomy-actors/src/main/scala/org/sunbird/actors/LockActor.scala
@@ -17,7 +17,6 @@ import org.sunbird.utils.Constants
 import java.text.SimpleDateFormat
 import java.util.concurrent.CompletionException
 import javax.inject.Inject
-import scala.collection.immutable.{List, Map}
 import scala.concurrent.{ExecutionContext, Future}
 
 class LockActor @Inject()(implicit oec: OntologyEngineContext) extends BaseActor{


### PR DESCRIPTION
- QuestionActor.scala: remove redundant 'import scala.collection.JavaConverters' (without wildcard) which is entirely subsumed by the subsequent 'import scala.collection.JavaConverters._'

- QuestionSetActor.scala: same JavaConverters duplicate as QuestionActor

- LockActor.scala: remove 'import scala.collection.immutable.{List, Map}' — both types are already in scope via scala.Predef and importing them explicitly creates a confusing apparent shadow of the builtins

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.12, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

