### PR TITLE
fix: rename package org.sunbird.mangers -> org.sunbird.managers

### DIFF
--- a/taxonomy-api/taxonomy-actors/src/main/scala/org/sunbird/actors/CategoryActor.scala
+++ b/taxonomy-api/taxonomy-actors/src/main/scala/org/sunbird/actors/CategoryActor.scala
@@ -12,7 +12,7 @@ import org.sunbird.graph.OntologyEngineContext
 import org.sunbird.graph.nodes.DataNode
 import org.sunbird.utils.Constants
 import org.sunbird.utils.taxonomy.RequestUtil
-import org.sunbird.mangers.FrameworkManager
+import org.sunbird.managers.FrameworkManager
 import org.sunbird.cache.impl.RedisCache
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/taxonomy-api/taxonomy-actors/src/main/scala/org/sunbird/actors/FrameworkActor.scala
+++ b/taxonomy-api/taxonomy-actors/src/main/scala/org/sunbird/actors/FrameworkActor.scala
@@ -11,7 +11,7 @@ import org.sunbird.graph.dac.model.{Node, SubGraph}
 import org.sunbird.graph.nodes.DataNode
 import org.sunbird.graph.path.DataSubGraph
 import org.sunbird.graph.utils.{NodeUtil, ScalaJsonUtils}
-import org.sunbird.mangers.FrameworkManager
+import org.sunbird.managers.FrameworkManager
 import org.sunbird.utils.{CategoryCache, FrameworkCache}
 import org.sunbird.utils.Constants
 import org.sunbird.utils.taxonomy.RequestUtil

--- a/taxonomy-api/taxonomy-actors/src/main/scala/org/sunbird/managers/FrameworkManager.scala
+++ b/taxonomy-api/taxonomy-actors/src/main/scala/org/sunbird/managers/FrameworkManager.scala
@@ -1,4 +1,4 @@
-package org.sunbird.mangers
+package org.sunbird.managers
 
 import java.util
 import org.apache.commons.lang3.StringUtils

--- a/taxonomy-api/taxonomy-actors/src/test/scala/org/sunbird/managers/FrameworkManagerTest.scala
+++ b/taxonomy-api/taxonomy-actors/src/test/scala/org/sunbird/managers/FrameworkManagerTest.scala
@@ -6,7 +6,7 @@ import org.sunbird.graph.OntologyEngineContext
 import org.sunbird.graph.dac.model.{Node, Relation, SubGraph}
 
 import java.util
-import org.sunbird.mangers.FrameworkManager._
+import org.sunbird.managers.FrameworkManager._
 
 import scala.collection.convert.ImplicitConversions._
 import scala.concurrent.ExecutionContext


### PR DESCRIPTION
The directory and package declaration contained a typo ('mangers' instead of 'managers'). This caused the file to sit in the wrong package path, making it inconsistent with the surrounding codebase.

Changes:
- Moved FrameworkManager.scala from sunbird/mangers/ to sunbird/managers/
- Updated package declaration in FrameworkManager.scala
- Updated import in FrameworkActor.scala
- Updated import in CategoryActor.scala
- Updated import in FrameworkManagerTest.scala



