### PR TITLE
fix: add close() and shutdown hook to KafkaClient to prevent resource…

### DIFF
--- a/platform-core/kafka-client/src/main/scala/org/sunbird/kafka/client/KafkaClient.scala
+++ b/platform-core/kafka-client/src/main/scala/org/sunbird/kafka/client/KafkaClient.scala
@@ -15,6 +15,8 @@ class KafkaClient {
 	private val producer = createProducer()
 	private val consumer = createConsumer()
 
+	registerShutdownHook()
+
 	protected def getProducer: Producer[Long, String] = producer
 	protected def getConsumer: Consumer[Long, String] = consumer
 
@@ -33,6 +35,33 @@ class KafkaClient {
 	def validate(topic: String): Boolean = {
 		val topics = getConsumer.listTopics
 		topics.keySet.contains(topic)
+	}
+
+	/**
+	 * Closes the Kafka producer and consumer, flushing any pending messages first.
+	 * Safe to call multiple times.
+	 */
+	def close(): Unit = {
+		try {
+			if (producer != null) {
+				producer.flush()
+				producer.close()
+			}
+		} catch {
+			case e: Exception => TelemetryManager.error("Error closing KafkaProducer: " + e.getMessage, e)
+		}
+		try {
+			if (consumer != null) consumer.close()
+		} catch {
+			case e: Exception => TelemetryManager.error("Error closing KafkaConsumer: " + e.getMessage, e)
+		}
+	}
+
+	private def registerShutdownHook(): Unit = {
+		Runtime.getRuntime.addShutdownHook(new Thread(() => {
+			TelemetryManager.log("Shutting down KafkaClient — closing producer and consumer")
+			close()
+		}))
 	}
 
 	private def createProducer(): KafkaProducer[Long, String] = {


### PR DESCRIPTION
… leak

KafkaProducer and KafkaConsumer were never closed, causing open connections and thread leaks when services shut down. This adds:
- close(): flushes producer, then closes both producer and consumer with individual try/catch so a failure in one doesn't skip closing the other
- registerShutdownHook(): registers a JVM shutdown hook to call close() automatically on normal or signal-based process exit

