### PR TITLE
refactor: extract magic literals to named constants

### DIFF
--- a/content-api/content-actors/src/main/scala/org/sunbird/channel/managers/ChannelManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/channel/managers/ChannelManager.scala
@@ -32,7 +32,7 @@ object ChannelManager {
   }
 
   def getAllFrameworkList(): util.List[util.Map[String, AnyRef]] = {
-    val url: String = Platform.getString("composite.search.url", "https://dev.sunbirded.org/action/composite/v3/search")
+    val url: String = Platform.getString(ChannelConstants.COMPOSITE_SEARCH_URL_CONFIG_KEY, ChannelConstants.COMPOSITE_SEARCH_URL_DEFAULT)
     val httpResponse: HttpResponse[String] = Unirest.post(url).header("Content-Type", "application/json").body("""{"request":{"filters":{"objectType":"Framework","status":"Live"},"fields":["name","code","objectType","identifier"]}}""").asString
     if (200 != httpResponse.getStatus)
       throw new ServerException("ERR_FETCHING_FRAMEWORK", "Error while fetching framework.")
@@ -110,7 +110,7 @@ object ChannelManager {
 
   def getAdditionalCategories()(implicit httpUtil: HttpUtil): java.util.List[String] = {
     val body = """{"request":{"filters":{"objectType":"ObjectCategory","visibility":["Default"]},"fields":["name","identifier"]}}"""
-    val url: String = Platform.getString("composite.search.url", "https://dev.sunbirded.org/action/composite/v3/search")
+    val url: String = Platform.getString(ChannelConstants.COMPOSITE_SEARCH_URL_CONFIG_KEY, ChannelConstants.COMPOSITE_SEARCH_URL_DEFAULT)
     val httpResponse = httpUtil.post(url, body)
     if (200 != httpResponse.status) throw new ServerException("ERR_FETCHING_OBJECT_CATEGORY", "Error while fetching object categories for additional category list.")
     val response: Response = JsonUtils.deserialize(httpResponse.body, classOf[Response])
@@ -138,7 +138,7 @@ object ChannelManager {
   }
 
   private def getPrimaryCategories(body: String)(implicit httpUtil: HttpUtil): java.util.List[java.util.Map[String, AnyRef]] =  {
-    val url: String = Platform.getString("composite.search.url", "https://dev.sunbirded.org/action/composite/v3/search")
+    val url: String = Platform.getString(ChannelConstants.COMPOSITE_SEARCH_URL_CONFIG_KEY, ChannelConstants.COMPOSITE_SEARCH_URL_DEFAULT)
     val httpResponse = httpUtil.post(url, body)
     if (200 != httpResponse.status) throw new ServerException("ERR_FETCHING_OBJECT_CATEGORY_DEFINITION", "Error while fetching primary categories.")
     val response: Response = JsonUtils.deserialize(httpResponse.body, classOf[Response])
@@ -147,7 +147,7 @@ object ChannelManager {
   }
 
   def getMasterCategoryList(): List[String] = {
-    val url: String = Platform.getString("composite.search.url", "https://dev.sunbirded.org/action/composite/v3/search")
+    val url: String = Platform.getString(ChannelConstants.COMPOSITE_SEARCH_URL_CONFIG_KEY, ChannelConstants.COMPOSITE_SEARCH_URL_DEFAULT)
     val httpResponse: HttpResponse[String] = Unirest.post(url).header("Content-Type", "application/json").body("""{"request":{"filters":{"objectType":"ObjectCategory"},"fields":["name"]}}""").asString
     if (200 != httpResponse.getStatus)
       throw new ServerException("ERR_FETCHING_OBJECT_CATEGORY", "Error while fetching object category.")

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ContentActor.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ContentActor.scala
@@ -311,8 +311,8 @@ class ContentActor @Inject() (implicit oec: OntologyEngineContext, ss: StorageSe
 			throw new ClientException("ERR_CONTENT_INVALID_FILE_NAME", "Please Provide Valid File Name.")
 		if (!preSignedObjTypes.contains(`type`))
 			throw new ClientException("ERR_INVALID_PRESIGNED_URL_TYPE", "Invalid pre-signed url type. It should be one of " + StringUtils.join(preSignedObjTypes, ","))
-		if(StringUtils.isNotBlank(filePath) && filePath.size > 100)
-			throw new ClientException("ERR_CONTENT_INVALID_FILE_PATH", "Please provide valid filepath of character length 100 or Less ")
+		if(StringUtils.isNotBlank(filePath) && filePath.size > ContentConstants.MAX_FILE_PATH_SIZE)
+			throw new ClientException("ERR_CONTENT_INVALID_FILE_PATH", "Please provide valid filepath of character length " + ContentConstants.MAX_FILE_PATH_SIZE + " or Less ")
 	}
 
 	def dataModifier(node: Node): Node = {

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/dial/DIALConstants.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/dial/DIALConstants.scala
@@ -28,4 +28,9 @@ object DIALConstants {
 	val DIAL_EID: String = "BE_QR_IMAGE_GENERATOR"
 	val batchInfo: String = "batchInfo"
 
+	// QR code generation defaults
+	val DEFAULT_ERROR_CORRECTION_LEVEL: String = "H"
+	val DEFAULT_PIXELS_PER_BLOCK: Int = 2
+	val DEFAULT_QR_CODE_MARGIN: Int = 3
+
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/dial/DIALManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/dial/DIALManager.scala
@@ -34,9 +34,9 @@ object DIALManager {
 	private val kfClient = new KafkaClient
 	val DIALTOPIC: String = Platform.config.getString("kafka.dial.request.topic")
 	val defaultConfig: Mmap[String, Any] = Mmap(
-		"errorCorrectionLevel" -> "H",
-		"pixelsPerBlock" -> 2,
-		"qrCodeMargin" -> 3,
+		"errorCorrectionLevel" -> DIALConstants.DEFAULT_ERROR_CORRECTION_LEVEL,
+		"pixelsPerBlock" -> DIALConstants.DEFAULT_PIXELS_PER_BLOCK,
+		"qrCodeMargin" -> DIALConstants.DEFAULT_QR_CODE_MARGIN,
 		"textFontName" -> "Verdana",
 		"textFontSize" -> 11,
 		"textCharacterSpacing" -> 0.1,

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/util/ContentConstants.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/util/ContentConstants.scala
@@ -79,4 +79,6 @@ object ContentConstants {
     val RELEASE: String = "release"
     val DRAFT: String = "Draft"
     val LIVE: String = "Live"
+
+    val MAX_FILE_PATH_SIZE: Int = 100
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/util/ChannelConstants.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/util/ChannelConstants.scala
@@ -20,4 +20,7 @@ object ChannelConstants {
   val categoryKeyList: List[String] = List(CONTENT_PRIMARY_CATEGORIES, COLLECTION_PRIMARY_CATEGORIES, ASSET_PRIMARY_CATEGORIES,
     CONTENT_ADDITIONAL_CATEGORIES, COLLECTION_ADDITIONAL_CATEGORIES, ASSET_ADDITIONAL_CATEGORIES)
 
+  val COMPOSITE_SEARCH_URL_CONFIG_KEY: String = "composite.search.url"
+  val COMPOSITE_SEARCH_URL_DEFAULT: String = "https://dev.sunbirded.org/action/composite/v3/search"
+
 }


### PR DESCRIPTION
Replace inline magic strings and numbers with named constants to improve readability and make future changes easier:

- ChannelConstants: add COMPOSITE_SEARCH_URL_CONFIG_KEY and COMPOSITE_SEARCH_URL_DEFAULT; ChannelManager uses them in all 4 call sites instead of repeating the raw string literals

- DIALConstants: add DEFAULT_ERROR_CORRECTION_LEVEL ("H"), DEFAULT_PIXELS_PER_BLOCK (2), DEFAULT_QR_CODE_MARGIN (3); DIALManager references them instead of inline literals in defaultConfig map

- ContentConstants: add MAX_FILE_PATH_SIZE (100); ContentActor uses it for the pre-signed URL file-path length guard and the error message

