### PR TITLE
fix: stop swallowing exceptions in ChannelManager and CollectionTOCUtil

### DIFF
--- a/content-api/collection-csv-actors/src/main/scala/org.sunbird/collectioncsv/util/CollectionTOCUtil.scala
+++ b/content-api/collection-csv-actors/src/main/scala/org.sunbird/collectioncsv/util/CollectionTOCUtil.scala
@@ -55,8 +55,9 @@ object CollectionTOCUtil {
       returnDIALCodes.asScala.toList.map(rec => rec.asScala.toMap[String,AnyRef]).map(_.getOrElse(CollectionTOCConstants.IDENTIFIER, "")).asInstanceOf[List[String]]
     }
     catch {
-      case e:Exception => println("CollectionTOCUtil: validateDIALCodes --> exception: " + e.getMessage)
-        List.empty
+      case e: Exception =>
+        TelemetryManager.error("CollectionTOCUtil: validateDIALCodes --> exception: " + e.getMessage, e)
+        throw new ServerException("ERR_DIALCODE_VALIDATION", "Error while parsing DIAL code validation response: " + e.getMessage)
     }
   }
 
@@ -94,8 +95,9 @@ object CollectionTOCUtil {
       contentList ++ questionSetList
     }
     catch {
-      case ex:Exception => TelemetryManager.info("CollectionTOCUtil --> searchLinkedContents --> Exception:: " + ex.getMessage)
-          List.empty
+      case ex: Exception =>
+        TelemetryManager.error("CollectionTOCUtil --> searchLinkedContents --> Exception: " + ex.getMessage, ex)
+        throw new ServerException("ERR_LINKED_CONTENT_SEARCH", "Error while parsing linked contents search response: " + ex.getMessage)
     }
   }
 

--- a/content-api/content-actors/src/main/scala/org/sunbird/channel/managers/ChannelManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/channel/managers/ChannelManager.scala
@@ -12,6 +12,7 @@ import com.mashape.unirest.http.Unirest
 import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
 import org.sunbird.common.JsonUtils
+import org.sunbird.telemetry.logger.TelemetryManager
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ListBuffer
@@ -103,8 +104,8 @@ object ChannelManager {
         metadata.put("additionalCategories", additionalCategories)
     } catch {
         case e: Exception =>
-            // Log error and continue without populating categories
-            System.out.println("Error fetching primary/additional categories: " + e.getMessage)
+            // Log error and continue; defaults are already populated above via putIfAbsent
+            TelemetryManager.error("Error fetching primary/additional categories: " + e.getMessage, e)
     }
   }
 


### PR DESCRIPTION
Three exception catch blocks were silently discarding failures, making problems invisible at runtime:

- ChannelManager.populateDefaultersForCreation: replaced System.out.println with TelemetryManager.error so category-fetch failures appear in logs. Intentional graceful-continue behaviour is preserved (defaults already applied via putIfAbsent before the try block).

- CollectionTOCUtil.validateDIALCodes: returning an empty list on parse failure caused all DIAL codes to appear valid even when the response could not be read. Now logs the error and re-throws a typed ServerException so callers know validation failed.

- CollectionTOCUtil.searchLinkedContents: returning an empty list on parse failure silently dropped linked-content results. Now logs the error and re-throws a typed ServerException so callers can handle the failure.

