### PR TITLE
refactor: replace println/System.out.println with TelemetryManager lo…

### DIFF
--- a/content-api/collection-csv-actors/src/main/scala/org.sunbird/collectioncsv/util/CollectionTOCUtil.scala
+++ b/content-api/collection-csv-actors/src/main/scala/org.sunbird/collectioncsv/util/CollectionTOCUtil.scala
@@ -55,7 +55,7 @@ object CollectionTOCUtil {
       returnDIALCodes.asScala.toList.map(rec => rec.asScala.toMap[String,AnyRef]).map(_.getOrElse(CollectionTOCConstants.IDENTIFIER, "")).asInstanceOf[List[String]]
     }
     catch {
-      case e:Exception => println("CollectionTOCUtil: validateDIALCodes --> exception: " + e.getMessage)
+      case e:Exception => TelemetryManager.error("CollectionTOCUtil: validateDIALCodes --> exception: " + e.getMessage, e)
         List.empty
     }
   }

--- a/content-api/content-actors/src/main/scala/org/sunbird/channel/managers/ChannelManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/channel/managers/ChannelManager.scala
@@ -12,6 +12,7 @@ import com.mashape.unirest.http.Unirest
 import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
 import org.sunbird.common.JsonUtils
+import org.sunbird.telemetry.logger.TelemetryManager
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ListBuffer
@@ -104,7 +105,7 @@ object ChannelManager {
     } catch {
         case e: Exception =>
             // Log error and continue without populating categories
-            System.out.println("Error fetching primary/additional categories: " + e.getMessage)
+            TelemetryManager.error("Error fetching primary/additional categories: " + e.getMessage, e)
     }
   }
 

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ContentActor.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ContentActor.scala
@@ -272,7 +272,7 @@ class ContentActor @Inject() (implicit oec: OntologyEngineContext, ss: StorageSe
                                 TelemetryManager.error("Error setting license to Redis: " + e.getMessage, e)
                         }
                     } else {
-                        println("Default License is not available for channel: " + channelId)
+                        TelemetryManager.warn("Default License is not available for channel: " + channelId)
                     }
                 }).recover {
                     case e: Exception =>

--- a/ontology-engine/graph-core_2.13/src/main/scala/org/sunbird/graph/validator/NodeValidator.scala
+++ b/ontology-engine/graph-core_2.13/src/main/scala/org/sunbird/graph/validator/NodeValidator.scala
@@ -9,6 +9,7 @@ import org.sunbird.graph.common.enums.SystemProperties
 import org.sunbird.graph.dac.model.{Filter, MetadataCriterion, Node, SearchConditions, SearchCriteria}
 import org.sunbird.graph.exception.GraphErrorCodes
 import org.sunbird.graph.service.operation.SearchAsyncOperations
+import org.sunbird.telemetry.logger.TelemetryManager
 import scala.jdk.CollectionConverters._
 
 import scala.collection.convert.ImplicitConversions._
@@ -34,7 +35,7 @@ object NodeValidator {
 
     private def getDataNodes(graphId: String, identifiers: util.List[String])(implicit ec: ExecutionContext, oec: OntologyEngineContext) = {
         if (identifiers.size() == 1) {
-            System.out.println("NodeValidator: Singular lookup for identifier: " + identifiers.get(0))
+            TelemetryManager.debug("NodeValidator: Singular lookup for identifier: " + identifiers.get(0))
             oec.graphService.getNodeByUniqueId(graphId, identifiers.get(0), false, new org.sunbird.common.dto.Request())
                 .map(node => util.Arrays.asList(node))
                 .recover {

--- a/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/path/DataSubGraph.scala
+++ b/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/path/DataSubGraph.scala
@@ -9,6 +9,7 @@ import org.sunbird.graph.dac.model.{Node, Relation, SubGraph}
 import org.sunbird.graph.nodes.DataNode
 import org.sunbird.graph.schema.{DefinitionFactory, DefinitionNode, ObjectCategoryDefinition}
 import org.sunbird.graph.utils.NodeUtil
+import org.sunbird.telemetry.logger.TelemetryManager
 import scala.jdk.CollectionConverters._
 import org.sunbird.graph.utils.NodeUtil.{convertJsonProperties, handleKeyNames}
 
@@ -37,7 +38,7 @@ object DataSubGraph {
     val dataMap = new util.HashMap[String, AnyRef]
     val relMap = new util.HashMap[String, AnyRef]
     readSubGraphData(request, dataMap, relMap).map(sub => {
-      println("subGraphData out " + sub)
+      TelemetryManager.debug("subGraphData out " + sub)
       sub
     })
   }
@@ -60,7 +61,7 @@ object DataSubGraph {
     })
     finalDataMap.asScala.map(entry => {
       val mapData = entry._2.asInstanceOf[java.util.Map[String, AnyRef]].asScala
-      println("mapData  " + mapData.toString())
+      TelemetryManager.debug("mapData  " + mapData.toString())
       val outRelations: util.List[Relation] = mapData.getOrElse("outRelations", new util.ArrayList[Relation]).asInstanceOf[util.List[Relation]]
       for (rel <- outRelations.asScala) {
         val subReq = new Request()
@@ -71,7 +72,7 @@ object DataSubGraph {
         subReq.getContext.put("objectType", rel.getEndNodeObjectType)
         subReq.getContext.put("isRoot", "true")
         subReq.put("identifier", rel.getEndNodeId)
-        println("readSubGraphData "+ readSubGraphData(subReq, dataMap, relMap))
+        TelemetryManager.debug("readSubGraphData " + subReq.get("identifier"))
       }
     })
     Future{finalDataMap}
@@ -107,7 +108,7 @@ object DataSubGraph {
         finalMetadata.keySet.retainAll(fields)
       finalMetadata.put("identifier", node.getIdentifier)
     }
-    println("definitionMap  "+ definitionMap)
+    TelemetryManager.debug("definitionMap  " + definitionMap)
     val relMap: util.Map[String, util.List[util.Map[String, AnyRef]]] = geOutRelationMap(node, updatedMetadataMap, definitionMap)
     finalMetadata.putAll(relMap)
     finalMetadata

--- a/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/path/DataSubGraph.scala
+++ b/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/path/DataSubGraph.scala
@@ -38,7 +38,6 @@ object DataSubGraph {
     val dataMap = new util.HashMap[String, AnyRef]
     val relMap = new util.HashMap[String, AnyRef]
     readSubGraphData(request, dataMap, relMap).map(sub => {
-      TelemetryManager.debug("subGraphData out " + sub)
       sub
     })
   }

--- a/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/path/DataSubGraph.scala
+++ b/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/path/DataSubGraph.scala
@@ -107,7 +107,6 @@ object DataSubGraph {
         finalMetadata.keySet.retainAll(fields)
       finalMetadata.put("identifier", node.getIdentifier)
     }
-    TelemetryManager.debug("definitionMap  " + definitionMap)
     val relMap: util.Map[String, util.List[util.Map[String, AnyRef]]] = geOutRelationMap(node, updatedMetadataMap, definitionMap)
     finalMetadata.putAll(relMap)
     finalMetadata

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/cloudstore/StorageService.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/cloudstore/StorageService.scala
@@ -6,6 +6,7 @@ import org.sunbird.cloud.storage.BaseStorageService
 import org.sunbird.cloud.storage.factory.{StorageConfig, StorageServiceFactory}
 import org.sunbird.common.{Platform, Slug}
 import org.sunbird.common.exception.ServerException
+import org.sunbird.telemetry.logger.TelemetryManager
 
 import java.io.File
 import scala.concurrent.{ExecutionContext, Future}
@@ -97,7 +98,7 @@ class StorageService {
            getService.getUri(getContainerName, key, Option.apply(false))
         } catch {
             case e:Exception =>
-              println("StorageService --> getUri --> Exception: " + e.getMessage)
+              TelemetryManager.error("StorageService --> getUri --> Exception: " + e.getMessage, e)
               ""
         }
     }

--- a/taxonomy-api/taxonomy-actors/src/main/scala/org/sunbird/actors/ObjectCategoryDefinitionActor.scala
+++ b/taxonomy-api/taxonomy-actors/src/main/scala/org/sunbird/actors/ObjectCategoryDefinitionActor.scala
@@ -7,6 +7,7 @@ import javax.inject.Inject
 import org.apache.commons.lang3.StringUtils
 import org.sunbird.actor.core.BaseActor
 import org.sunbird.common.{JsonUtils, Slug}
+import org.sunbird.telemetry.logger.TelemetryManager
 import org.sunbird.common.dto.{Request, Response, ResponseHandler}
 import org.sunbird.common.exception.{ClientException, ResourceNotFoundException}
 import org.sunbird.graph.OntologyEngineContext
@@ -78,7 +79,7 @@ class ObjectCategoryDefinitionActor @Inject()(implicit oec: OntologyEngineContex
 		DataNode.read(request) recoverWith {
 			case e: ResourceNotFoundException => {
 				val id = request.get(Constants.IDENTIFIER).asInstanceOf[String]
-				println("ObjectCategoryDefinitionActor ::: read ::: node not found with id :" + id + " | Fetching node with _all")
+				TelemetryManager.debug("ObjectCategoryDefinitionActor ::: read ::: node not found with id :" + id + " | Fetching node with _all")
 				if (StringUtils.equalsAnyIgnoreCase("POST", requestMethod) && !StringUtils.endsWithIgnoreCase(id, "_all")) {
 					request.put(Constants.IDENTIFIER, id.replace(id.substring(id.lastIndexOf("_") + 1), "all"))
 					DataNode.read(request)
@@ -87,7 +88,7 @@ class ObjectCategoryDefinitionActor @Inject()(implicit oec: OntologyEngineContex
 			}
 			case e: CompletionException if e.getCause.isInstanceOf[ResourceNotFoundException] => {
 				val id = request.get(Constants.IDENTIFIER).asInstanceOf[String]
-				println("ObjectCategoryDefinitionActor ::: read ::: node not found with id :" + id + " | Fetching node with _all")
+				TelemetryManager.debug("ObjectCategoryDefinitionActor ::: read ::: node not found with id :" + id + " | Fetching node with _all")
 				if (StringUtils.equalsAnyIgnoreCase("POST", requestMethod) && !StringUtils.endsWithIgnoreCase(id, "_all")) {
 					request.put(Constants.IDENTIFIER, id.replace(id.substring(id.lastIndexOf("_") + 1), "all"))
 					DataNode.read(request)


### PR DESCRIPTION
…gging

Replace all raw println and System.out.println calls in business logic with structured TelemetryManager calls (debug/error/warn) so that log output is captured by the platform's logging pipeline and not silently dropped in production.

Files changed:
- ContentActor.scala: warn for missing default licence
- ChannelManager.scala: error for category fetch failure (added import)
- NodeValidator.scala: debug for singular identifier lookup (added import)
- DataSubGraph.scala: debug for subgraph traversal diagnostics (added import)
- StorageService.scala: error for getUri exception (added import)
- CollectionTOCUtil.scala: error for validateDIALCodes exception
- ObjectCategoryDefinitionActor.scala: debug for fallback _all lookup (added import)

