### PR TITLE
fix: JanusGraph property cardinality and hierarchy serialization fixes

### DIFF
--- a/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/HierarchyManager.scala
+++ b/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/HierarchyManager.scala
@@ -325,7 +325,7 @@ object HierarchyManager {
             childNodes.addAll(leafNodes)
         if(operation.equalsIgnoreCase("remove"))
             childNodes.removeAll(leafNodes)
-        req.put("childNodes", childNodes.asScala.toList.distinct.toArray)
+        req.put("childNodes", childNodes.asScala.toList.distinct.asJava)
         req.getContext.put("identifier", rootNode.getIdentifier.replaceAll(imgSuffix, ""))
         req.getContext.put("skipValidation", java.lang.Boolean.TRUE)
         DataNode.update(req)

--- a/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/dac/util/JanusGraphNodeUtil.java
+++ b/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/dac/util/JanusGraphNodeUtil.java
@@ -103,17 +103,30 @@ public class JanusGraphNodeUtil {
                 node.setObjectType(value.toString());
             } else if (!StringUtils.equalsIgnoreCase(key, "graphId")) {
                 if (value instanceof List) {
-                    // Keep as List to match Neo4j behavior
                     metadata.put(key, new ArrayList<>((List<?>) value));
-                } else if (value instanceof String && ((String) value).startsWith("[")
-                        && ((String) value).endsWith("]")) {
-                    try {
-                        metadata.put(key, mapper.readValue((String) value, List.class));
-                    } catch (Exception e) {
+                } else {
+                    if (value instanceof String) {
+                        String sv = (String) value;
+                        if (sv.startsWith("[") && sv.endsWith("]")) {
+                            try {
+                                value = mapper.readValue(sv, ArrayList.class);
+                            } catch (Exception ignored) {
+                            }
+                        }
+                    }
+                    if (metadata.containsKey(key)) {
+                        Object existing = metadata.get(key);
+                        if (existing instanceof List) {
+                            ((List<Object>) existing).add(value);
+                        } else {
+                            List<Object> list = new ArrayList<>();
+                            list.add(existing);
+                            list.add(value);
+                            metadata.put(key, list);
+                        }
+                    } else {
                         metadata.put(key, value);
                     }
-                } else {
-                    metadata.put(key, value);
                 }
             }
         }
@@ -158,12 +171,8 @@ public class JanusGraphNodeUtil {
 
         relation.setStartNodeId(startId != null ? startId.toString() : null);
         relation.setEndNodeId(endId != null ? endId.toString() : null);
-
-        // Populate objectType, name, and node metadata from vertices
-        // These are required by NodeUtil.getRelationMap() to build the relation lookup key
-        // (e.g., "associatedTo_out_AssessmentItem" -> "questions") and by
-        // NodeUtil.populateRelationMaps() to populate name, description, status fields.
-        relation.setStartNodeObjectType(getVertexStringProperty(startVertex, SystemProperties.IL_FUNC_OBJECT_TYPE.name()));
+        relation.setStartNodeObjectType(
+                getVertexStringProperty(startVertex, SystemProperties.IL_FUNC_OBJECT_TYPE.name()));
         relation.setEndNodeObjectType(getVertexStringProperty(endVertex, SystemProperties.IL_FUNC_OBJECT_TYPE.name()));
         relation.setStartNodeName(getVertexStringProperty(startVertex, "name"));
         relation.setEndNodeName(getVertexStringProperty(endVertex, "name"));

--- a/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/operation/NodeAsyncOperations.java
+++ b/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/operation/NodeAsyncOperations.java
@@ -103,7 +103,12 @@ public class NodeAsyncOperations {
                     }
                 }
 
-                tx.commit();
+                try {
+                    tx.commit();
+                } catch (Exception commitEx) {
+                    TelemetryManager.error("Commit failed for node " + identifier + ": " + commitEx.getMessage(), commitEx);
+                    throw commitEx;
+                }
 
                 node.setGraphId(graphId);
                 node.setIdentifier(identifier);
@@ -112,9 +117,6 @@ public class NodeAsyncOperations {
                 return node;
 
             } catch (Exception e) {
-                if (null != tx)
-                    tx.rollback();
-
                 TelemetryManager.error("Error adding node: " + e.getMessage(), e);
                 if (e instanceof MiddlewareException) {
                     throw e;
@@ -127,6 +129,12 @@ public class NodeAsyncOperations {
                 } else {
                     throw new ServerException(DACErrorCodeConstants.SERVER_ERROR.name(),
                             "Error! Something went wrong while creating node object. ", e);
+                }
+            } finally {
+                if (null != tx && tx.isOpen()) {
+                    try { tx.rollback(); } catch (Exception ex) {
+                        TelemetryManager.error("Error rolling back addNode transaction: " + ex.getMessage(), ex);
+                    }
                 }
             }
         }));
@@ -258,7 +266,7 @@ public class NodeAsyncOperations {
                     try {
                         tx.rollback();
                     } catch (Exception ex) {
-                        TelemetryManager.error("Error performing rollback: " + ex.getMessage(), ex);
+                        TelemetryManager.error("Error rolling back upsertNode transaction: " + ex.getMessage(), ex);
                     }
                 }
             }
@@ -328,11 +336,15 @@ public class NodeAsyncOperations {
                 return rootNode;
 
             } catch (Exception e) {
-                if (null != tx)
-                    tx.rollback();
                 TelemetryManager.error("Error upserting root node: " + e.getMessage(), e);
                 throw new ServerException(DACErrorCodeConstants.SERVER_ERROR.name(),
                         "Error! Something went wrong while upserting root node. ", e);
+            } finally {
+                if (null != tx && tx.isOpen()) {
+                    try { tx.rollback(); } catch (Exception ex) {
+                        TelemetryManager.error("Error rolling back upsertRootNode transaction: " + ex.getMessage(), ex);
+                    }
+                }
             }
         }));
     }
@@ -377,11 +389,15 @@ public class NodeAsyncOperations {
                 }
 
             } catch (Exception e) {
-                if (null != tx)
-                    tx.rollback();
                 TelemetryManager.error("Error deleting node: " + e.getMessage(), e);
                 throw new ServerException(DACErrorCodeConstants.SERVER_ERROR.name(),
                         "Error! Something went wrong while deleting node. ", e);
+            } finally {
+                if (null != tx && tx.isOpen()) {
+                    try { tx.rollback(); } catch (Exception ex) {
+                        TelemetryManager.error("Error rolling back deleteNode transaction: " + ex.getMessage(), ex);
+                    }
+                }
             }
         }));
     }
@@ -463,11 +479,15 @@ public class NodeAsyncOperations {
                 return updatedNodes;
 
             } catch (Exception e) {
-                if (null != tx)
-                    tx.rollback();
                 TelemetryManager.error("Error updating nodes: " + e.getMessage(), e);
                 throw new ServerException(DACErrorCodeConstants.SERVER_ERROR.name(),
                         "Error! Something went wrong while updating nodes. ", e);
+            } finally {
+                if (null != tx && tx.isOpen()) {
+                    try { tx.rollback(); } catch (Exception ex) {
+                        TelemetryManager.error("Error rolling back updateNodes transaction: " + ex.getMessage(), ex);
+                    }
+                }
             }
         }));
     }
@@ -488,19 +508,16 @@ public class NodeAsyncOperations {
                     if (value instanceof Map) {
                         value = JsonUtils.serialize(value);
                     } else if (value instanceof List) {
-                        // Serialize ALL lists (strings, maps, mixed) to JSON strings.
                         value = JsonUtils.serialize(value);
                     } else if (value instanceof Object[]) {
                         value = JsonUtils.serialize(Arrays.asList((Object[]) value));
                     }
-                    // String, Number, Boolean pass through unchanged.
                 } catch (Exception e) {
-                    TelemetryManager.error(
-                            "Exception Occurred While Processing Primitive Data Types | Key: " + key
-                                    + " | Exception is : " + e.getMessage(), e);
+                    TelemetryManager.error("Exception Occurred While Processing Primitive Data Types | Key: " + key
+                            + " | Exception is : " + e.getMessage(), e);
                 }
             }
-            result.put(key, value != null ? value : "");
+            result.put(key, value);
         }
         return result;
     }

--- a/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/operation/NodeAsyncOperations.java
+++ b/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/operation/NodeAsyncOperations.java
@@ -4,6 +4,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.janusgraph.core.JanusGraphTransaction;
 import org.janusgraph.core.JanusGraphVertex;
 import org.sunbird.common.DateUtils;
@@ -84,35 +85,17 @@ public class NodeAsyncOperations {
 
                 // Create vertex using Native API
                 JanusGraphVertex vertex = tx.addVertex(node.getObjectType());
-                vertex.property(SystemProperties.IL_UNIQUE_ID.name(), identifier);
-                vertex.property("graphId", graphId);
-                vertex.property(SystemProperties.IL_FUNC_OBJECT_TYPE.name(), node.getObjectType());
-                vertex.property(SystemProperties.IL_SYS_NODE_TYPE.name(),
+                vertex.property(VertexProperty.Cardinality.single, SystemProperties.IL_UNIQUE_ID.name(), identifier);
+                vertex.property(VertexProperty.Cardinality.single, "graphId", graphId);
+                vertex.property(VertexProperty.Cardinality.single, SystemProperties.IL_FUNC_OBJECT_TYPE.name(),
+                        node.getObjectType());
+                vertex.property(VertexProperty.Cardinality.single, SystemProperties.IL_SYS_NODE_TYPE.name(),
                         StringUtils.isNotBlank(node.getNodeType()) ? node.getNodeType()
                                 : SystemNodeTypes.DATA_NODE.name());
 
-                // Add all metadata properties
                 for (Map.Entry<String, Object> entry : metadata.entrySet()) {
                     if (entry.getValue() != null) {
-                        Object value = entry.getValue();
-                        if (value instanceof java.util.List) {
-                            java.util.List<?> list = (java.util.List<?>) value;
-                            if (list.isEmpty()) {
-                                // If list is empty, skip property creation
-                                continue;
-                            }
-                            // Convert to typed array for JanusGraph
-                            if (list.get(0) instanceof String) {
-                                value = list.toArray(new String[0]);
-                            } else if (list.get(0) instanceof Integer) {
-                                value = list.toArray(new Integer[0]);
-                            } else if (list.get(0) instanceof Double) {
-                                value = list.toArray(new Double[0]);
-                            } else {
-                                value = list.toArray();
-                            }
-                        }
-                        vertex.property(entry.getKey(), value);
+                        vertex.property(VertexProperty.Cardinality.single, entry.getKey(), entry.getValue());
                     }
                 }
 
@@ -195,10 +178,12 @@ public class NodeAsyncOperations {
                     node.getMetadata().put(AuditProperties.lastUpdatedOn.name(), timestamp);
 
                     vertex = tx.addVertex(node.getObjectType());
-                    vertex.property(SystemProperties.IL_UNIQUE_ID.name(), identifier);
-                    vertex.property("graphId", graphId);
-                    vertex.property(SystemProperties.IL_FUNC_OBJECT_TYPE.name(), node.getObjectType());
-                    vertex.property(SystemProperties.IL_SYS_NODE_TYPE.name(),
+                    vertex.property(VertexProperty.Cardinality.single, SystemProperties.IL_UNIQUE_ID.name(),
+                            identifier);
+                    vertex.property(VertexProperty.Cardinality.single, "graphId", graphId);
+                    vertex.property(VertexProperty.Cardinality.single, SystemProperties.IL_FUNC_OBJECT_TYPE.name(),
+                            node.getObjectType());
+                    vertex.property(VertexProperty.Cardinality.single, SystemProperties.IL_SYS_NODE_TYPE.name(),
                             StringUtils.isNotBlank(node.getNodeType()) ? node.getNodeType()
                                     : SystemNodeTypes.DATA_NODE.name());
                 }
@@ -213,7 +198,8 @@ public class NodeAsyncOperations {
                 Map<String, Object> metadata = setPrimitiveData(node.getMetadata());
 
                 // Determine which properties to write.
-                // If updatedFields is set (update flow), only write those properties + system-generated ones.
+                // If updatedFields is set (update flow), only write those properties +
+                // system-generated ones.
                 // If updatedFields is null/empty (create flow or legacy), write all properties.
                 Set<String> updatedFields = node.getUpdatedFields();
                 boolean isPartialUpdate = (isExistingNode && updatedFields != null && !updatedFields.isEmpty());
@@ -226,7 +212,7 @@ public class NodeAsyncOperations {
                             + " | Updating only fields: " + updatedFields);
                 }
 
-                // Update properties
+                // Update properties using VertexProperty.Cardinality.single
                 for (Map.Entry<String, Object> entry : metadata.entrySet()) {
                     // Skip properties not in the update set (for partial updates)
                     if (isPartialUpdate && !updatedFields.contains(entry.getKey())) {
@@ -239,18 +225,7 @@ public class NodeAsyncOperations {
                         }
                         continue;
                     }
-                    Object value = entry.getValue();
-                    if (value instanceof java.util.List) {
-                        java.util.List<?> list = (java.util.List<?>) value;
-                        if (list.isEmpty()) {
-                            if (vertex.keys().contains(entry.getKey())) {
-                                vertex.property(entry.getKey()).remove();
-                            }
-                            continue;
-                        }
-                        value = list.toArray();
-                    }
-                    vertex.property(entry.getKey(), value);
+                    vertex.property(VertexProperty.Cardinality.single, entry.getKey(), entry.getValue());
                 }
 
                 try {
@@ -314,15 +289,20 @@ public class NodeAsyncOperations {
                 if (!vertexIter.hasNext()) {
                     // Create root node
                     vertex = tx.addVertex("ROOT");
-                    vertex.property(SystemProperties.IL_UNIQUE_ID.name(), rootId);
-                    vertex.property("graphId", graphId);
-                    vertex.property(SystemProperties.IL_FUNC_OBJECT_TYPE.name(), "ROOT");
-                    vertex.property(SystemProperties.IL_SYS_NODE_TYPE.name(), SystemNodeTypes.DATA_NODE.name());
-                    vertex.property(AuditProperties.createdOn.name(), DateUtils.formatCurrentDate());
-                    vertex.property(AuditProperties.lastUpdatedOn.name(), DateUtils.formatCurrentDate());
+                    vertex.property(VertexProperty.Cardinality.single, SystemProperties.IL_UNIQUE_ID.name(), rootId);
+                    vertex.property(VertexProperty.Cardinality.single, "graphId", graphId);
+                    vertex.property(VertexProperty.Cardinality.single, SystemProperties.IL_FUNC_OBJECT_TYPE.name(),
+                            "ROOT");
+                    vertex.property(VertexProperty.Cardinality.single, SystemProperties.IL_SYS_NODE_TYPE.name(),
+                            SystemNodeTypes.DATA_NODE.name());
+                    vertex.property(VertexProperty.Cardinality.single, AuditProperties.createdOn.name(),
+                            DateUtils.formatCurrentDate());
+                    vertex.property(VertexProperty.Cardinality.single, AuditProperties.lastUpdatedOn.name(),
+                            DateUtils.formatCurrentDate());
                 } else {
                     vertex = vertexIter.next();
-                    vertex.property(AuditProperties.lastUpdatedOn.name(), DateUtils.formatCurrentDate());
+                    vertex.property(VertexProperty.Cardinality.single, AuditProperties.lastUpdatedOn.name(),
+                            DateUtils.formatCurrentDate());
                 }
 
                 try {
@@ -525,21 +505,24 @@ public class NodeAsyncOperations {
             TelemetryManager.log("Channel from request: " + channel + " for content: " + node.getIdentifier());
             if (StringUtils.isNotBlank(channel)) {
                 node.getMetadata().put(GraphDACParams.channel.name(), channel);
-                if (updatedFields != null) updatedFields.add(GraphDACParams.channel.name());
+                if (updatedFields != null)
+                    updatedFields.add(GraphDACParams.channel.name());
             }
 
             String consumerId = (String) request.getContext().get(GraphDACParams.CONSUMER_ID.name());
             TelemetryManager.log("ConsumerId from request: " + consumerId + " for content: " + node.getIdentifier());
             if (StringUtils.isNotBlank(consumerId)) {
                 node.getMetadata().put(GraphDACParams.consumerId.name(), consumerId);
-                if (updatedFields != null) updatedFields.add(GraphDACParams.consumerId.name());
+                if (updatedFields != null)
+                    updatedFields.add(GraphDACParams.consumerId.name());
             }
 
             String appId = (String) request.getContext().get(GraphDACParams.APP_ID.name());
             TelemetryManager.log("App Id from request: " + appId + " for content: " + node.getIdentifier());
             if (StringUtils.isNotBlank(appId)) {
                 node.getMetadata().put(GraphDACParams.appId.name(), appId);
-                if (updatedFields != null) updatedFields.add(GraphDACParams.appId.name());
+                if (updatedFields != null)
+                    updatedFields.add(GraphDACParams.appId.name());
             }
         }
     }

--- a/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/operation/NodeAsyncOperations.java
+++ b/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/operation/NodeAsyncOperations.java
@@ -29,13 +29,14 @@ import org.sunbird.telemetry.logger.TelemetryManager;
 import scala.compat.java8.FutureConverters;
 import scala.concurrent.Future;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 /**
  * Node async operations using JanusGraph/Gremlin
@@ -80,7 +81,7 @@ public class NodeAsyncOperations {
                 String versionKey = Identifier.getUniqueIdFromTimestamp();
                 node.getMetadata().put(GraphDACParams.versionKey.name(), versionKey);
 
-                // Process primitive data types (serialize complex objects)
+                // Serialize complex objects (Maps, Lists, Arrays) to JSON strings —
                 Map<String, Object> metadata = setPrimitiveData(node.getMetadata());
 
                 // Create vertex using Native API
@@ -93,9 +94,12 @@ public class NodeAsyncOperations {
                         StringUtils.isNotBlank(node.getNodeType()) ? node.getNodeType()
                                 : SystemNodeTypes.DATA_NODE.name());
 
+                // After setPrimitiveData all complex types are JSON strings — use single cardinality.
                 for (Map.Entry<String, Object> entry : metadata.entrySet()) {
-                    if (entry.getValue() != null) {
-                        vertex.property(VertexProperty.Cardinality.single, entry.getKey(), entry.getValue());
+                    String key = entry.getKey();
+                    Object value = entry.getValue();
+                    if (value != null) {
+                        vertex.property(VertexProperty.Cardinality.single, key, value);
                     }
                 }
 
@@ -198,11 +202,11 @@ public class NodeAsyncOperations {
                 Map<String, Object> metadata = setPrimitiveData(node.getMetadata());
 
                 // Determine which properties to write.
-                // If updatedFields is set (update flow), only write those properties +
-                // system-generated ones.
-                // If updatedFields is null/empty (create flow or legacy), write all properties.
                 Set<String> updatedFields = node.getUpdatedFields();
-                boolean isPartialUpdate = (isExistingNode && updatedFields != null && !updatedFields.isEmpty());
+                if (updatedFields == null) {
+                    updatedFields = new HashSet<>();
+                }
+                boolean isPartialUpdate = (isExistingNode && !updatedFields.isEmpty());
 
                 if (isPartialUpdate) {
                     // Add system-generated properties that must always be written
@@ -212,29 +216,28 @@ public class NodeAsyncOperations {
                             + " | Updating only fields: " + updatedFields);
                 }
 
-                // Update properties using VertexProperty.Cardinality.single
                 for (Map.Entry<String, Object> entry : metadata.entrySet()) {
                     // Skip properties not in the update set (for partial updates)
                     if (isPartialUpdate && !updatedFields.contains(entry.getKey())) {
                         continue;
                     }
-                    if (entry.getValue() == null) {
-                        // Null value means property should be removed (e.g. removeProps)
-                        if (vertex.keys().contains(entry.getKey())) {
-                            vertex.property(entry.getKey()).remove();
-                        }
+
+                    String key = entry.getKey();
+                    Object value = entry.getValue();
+
+                    // Drop all existing vertex properties for this key before writing. To avoid appending values
+                    Iterator<VertexProperty<Object>> it = vertex.properties(key);
+                    while (it.hasNext()) {
+                        it.next().remove();
+                    }
+
+                    if (value == null) {
                         continue;
                     }
-                    vertex.property(VertexProperty.Cardinality.single, entry.getKey(), entry.getValue());
+                    vertex.property(VertexProperty.Cardinality.single, key, value);
                 }
 
-                try {
-                    tx.commit();
-                } catch (Exception commitEx) {
-                    TelemetryManager.error("NodeAsyncOperations.upsertNode: EXCEPTION during commit for " + identifier
-                            + ": " + commitEx.getMessage(), commitEx);
-                    throw commitEx;
-                }
+                tx.commit();
 
                 node.setGraphId(graphId);
                 node.setIdentifier(identifier);
@@ -243,14 +246,20 @@ public class NodeAsyncOperations {
                 return node;
 
             } catch (Exception e) {
-                if (null != tx)
-                    tx.rollback();
                 TelemetryManager.error("Error upserting node: " + e.getMessage(), e);
                 if (e instanceof MiddlewareException) {
                     throw (MiddlewareException) e;
                 } else {
                     throw new ServerException(DACErrorCodeConstants.SERVER_ERROR.name(),
-                            "Error! Something went wrong while upserting node object. ", e);
+                            "Error! Something went wrong while upserting node object: " + e.getMessage(), e);
+                }
+            } finally {
+                if (null != tx && tx.isOpen()) {
+                    try {
+                        tx.rollback();
+                    } catch (Exception ex) {
+                        TelemetryManager.error("Error performing rollback: " + ex.getMessage(), ex);
+                    }
                 }
             }
         }));
@@ -426,8 +435,12 @@ public class NodeAsyncOperations {
 
                         // Update properties
                         for (Map.Entry<String, Object> entry : metadata.entrySet()) {
-                            if (entry.getValue() != null) {
-                                vertex.property(VertexProperty.Cardinality.single, entry.getKey(), entry.getValue());
+                            String key = entry.getKey();
+                            Object value = entry.getValue();
+                            if (value != null) {
+                                // Drop existing properties before updating to avoid appending
+                                vertex.properties(key).forEachRemaining(vp -> vp.remove());
+                                vertex.property(VertexProperty.Cardinality.single, key, value);
                             }
                         }
 
@@ -466,24 +479,30 @@ public class NodeAsyncOperations {
             return new HashMap<>();
         }
 
-        return metadata.entrySet().stream()
-                .peek(entry -> {
-                    Object value = entry.getValue();
-                    try {
-                        if (value instanceof Map) {
-                            value = JsonUtils.serialize(value);
-                        } else if (value instanceof List) {
-                            value = JsonUtils.serialize(value);
-                        }
-                        entry.setValue(value);
-                    } catch (Exception e) {
-                        TelemetryManager
-                                .error("Exception Occurred While Processing Primitive Data Types | Exception is : "
-                                        + e.getMessage(), e);
+        Map<String, Object> result = new HashMap<>();
+        for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (value != null) {
+                try {
+                    if (value instanceof Map) {
+                        value = JsonUtils.serialize(value);
+                    } else if (value instanceof List) {
+                        // Serialize ALL lists (strings, maps, mixed) to JSON strings.
+                        value = JsonUtils.serialize(value);
+                    } else if (value instanceof Object[]) {
+                        value = JsonUtils.serialize(Arrays.asList((Object[]) value));
                     }
-                })
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue() != null ? entry.getValue() : "",
-                        (v1, v2) -> v2, HashMap::new));
+                    // String, Number, Boolean pass through unchanged.
+                } catch (Exception e) {
+                    TelemetryManager.error(
+                            "Exception Occurred While Processing Primitive Data Types | Key: " + key
+                                    + " | Exception is : " + e.getMessage(), e);
+                }
+            }
+            result.put(key, value != null ? value : "");
+        }
+        return result;
     }
 
     private static void setRequestContextToNode(Node node, Request request) {

--- a/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/operation/NodeAsyncOperations.java
+++ b/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/operation/NodeAsyncOperations.java
@@ -438,7 +438,7 @@ public class NodeAsyncOperations {
                                     }
                                     value = list.toArray();
                                 }
-                                vertex.property(entry.getKey(), value);
+                                vertex.property(VertexProperty.Cardinality.single, entry.getKey(), value);
                             }
                         }
 

--- a/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/operation/NodeAsyncOperations.java
+++ b/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/operation/NodeAsyncOperations.java
@@ -427,18 +427,7 @@ public class NodeAsyncOperations {
                         // Update properties
                         for (Map.Entry<String, Object> entry : metadata.entrySet()) {
                             if (entry.getValue() != null) {
-                                Object value = entry.getValue();
-                                if (value instanceof java.util.List) {
-                                    java.util.List<?> list = (java.util.List<?>) value;
-                                    if (list.isEmpty()) {
-                                        if (vertex.keys().contains(entry.getKey())) {
-                                            vertex.property(entry.getKey()).remove();
-                                        }
-                                        continue;
-                                    }
-                                    value = list.toArray();
-                                }
-                                vertex.property(VertexProperty.Cardinality.single, entry.getKey(), value);
+                                vertex.property(VertexProperty.Cardinality.single, entry.getKey(), entry.getValue());
                             }
                         }
 


### PR DESCRIPTION
- Enforces VertexProperty.Cardinality.single to prevent property accumulation in JanusGraph.
- Fixes childNodes serialization corruption in HierarchyManager by using .asJava.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.12, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

