### PR TITLE
feat: make Redis optional - all cache paths fall back to DB when redis.enable=false

### DIFF
--- a/assessment-api/assessment-actors/src/test/resources/application.conf
+++ b/assessment-api/assessment-actors/src/test/resources/application.conf
@@ -287,6 +287,7 @@ cassandra.lpa.connection="127.0.0.1:9042,127.0.0.2:9042,127.0.0.3:9042"
 redis.host=localhost
 redis.port=6379
 redis.maxConnections=128
+redis.enable = false
 
 #Condition to enable publish locally
 content.publish_task.enabled=true

--- a/assessment-api/assessment-service/conf/application.conf
+++ b/assessment-api/assessment-service/conf/application.conf
@@ -362,9 +362,14 @@ cassandra.lp.connection="127.0.0.1:9042"
 content.keyspace = "content_store"
 
 # Redis Configuration
-redis.host="localhost"
-redis.port=6379
-redis.maxConnections=128
+# Disabled by default.
+redis.host = "localhost"
+redis.port = 6379
+redis.maxConnections = 128
+redis.enable = false
+
+# QuestionSet hierarchy caching (requires redis.enable=true)
+questionset.cache.enable = false
 
 # Graph Configuration
 graph.dir=/data/testingGraphDB

--- a/content-api/content-actors/src/test/resources/application.conf
+++ b/content-api/content-actors/src/test/resources/application.conf
@@ -287,6 +287,7 @@ cassandra.lpa.connection="127.0.0.1:9042,127.0.0.2:9042,127.0.0.3:9042"
 redis.host=localhost
 redis.port=6379
 redis.maxConnections=128
+redis.enable = false
 
 #Condition to enable publish locally
 content.publish_task.enabled=true

--- a/content-api/content-service/conf/application.conf
+++ b/content-api/content-service/conf/application.conf
@@ -393,9 +393,11 @@ cassandra.lp.connection="127.0.0.1:9042"
 cassandra.lpa.connection="127.0.0.1:9042"
 
 # Redis Configuration
-redis.host=localhost
-redis.port=6379
-redis.maxConnections=128
+# Disabled by default.
+redis.host = "localhost"
+redis.port = 6379
+redis.maxConnections = 128
+redis.enable = false
 
 #Condition to enable publish locally
 content.publish_task.enabled=true
@@ -575,13 +577,13 @@ cassandra.lp.consistency.level=QUORUM
 content.nested.fields="badgeAssertions,targets,badgeAssociations"
 
 content.cache.ttl=86400
-content.cache.enable=true
-collection.cache.enable=true
+content.cache.enable = false
+collection.cache.enable = false
 content.discard.status=["Draft","FlagDraft"]
 
 framework.categories_cached=["subject", "medium", "gradeLevel", "board"]
 framework.cache.ttl=86400
-framework.cache.read=true
+framework.cache.read = false
 
 
 # Max size(width/height) of thumbnail in pixels

--- a/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/HierarchyManager.scala
+++ b/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/HierarchyManager.scala
@@ -205,7 +205,8 @@ object HierarchyManager {
 
     @throws[Exception]
     def getPublishedHierarchy(request: Request)(implicit ec: ExecutionContext, oec: OntologyEngineContext): Future[Response] = {
-        val redisHierarchy = RedisCache.get(hierarchyPrefix + request.get("rootId"))
+        val collectionCacheEnabled = Platform.getBoolean("collection.cache.enable", false)
+        val redisHierarchy = if (collectionCacheEnabled) RedisCache.get(hierarchyPrefix + request.get("rootId")) else ""
         val hierarchyFuture = if (StringUtils.isNotEmpty(redisHierarchy)) {
             Future(Map("content" -> JsonUtils.deserialize(redisHierarchy, classOf[java.util.Map[String, AnyRef]])).asJava)
         } else getCassandraHierarchy(request)

--- a/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
+++ b/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
@@ -192,6 +192,7 @@ object UpdateHierarchyManager {
                 childData.put(HierarchyConstants.AUDIENCE, rootNode.getMetadata.get(HierarchyConstants.AUDIENCE) )
                 HierarchyBackwardCompatibilityUtil.setContentAndCategoryTypes(childData)
                 val node = NodeUtil.deserialize(childData, request.getContext.get(HierarchyConstants.SCHEMA_NAME).asInstanceOf[String], DefinitionNode.getRelationsMap(request))
+                node.setGraphId(HierarchyConstants.TAXONOMY_ID)
                 HierarchyBackwardCompatibilityUtil.setNewObjectType(node)
                 val updatedNodes = node :: nodes
                 Future(updatedNodes)

--- a/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
+++ b/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
@@ -192,7 +192,6 @@ object UpdateHierarchyManager {
                 childData.put(HierarchyConstants.AUDIENCE, rootNode.getMetadata.get(HierarchyConstants.AUDIENCE) )
                 HierarchyBackwardCompatibilityUtil.setContentAndCategoryTypes(childData)
                 val node = NodeUtil.deserialize(childData, request.getContext.get(HierarchyConstants.SCHEMA_NAME).asInstanceOf[String], DefinitionNode.getRelationsMap(request))
-                node.setGraphId(HierarchyConstants.TAXONOMY_ID)
                 HierarchyBackwardCompatibilityUtil.setNewObjectType(node)
                 val updatedNodes = node :: nodes
                 Future(updatedNodes)

--- a/knowlg-service/conf/application.conf
+++ b/knowlg-service/conf/application.conf
@@ -467,9 +467,11 @@ cassandra.lp.connection="127.0.0.1:9042"
 cassandra.lpa.connection="127.0.0.1:9042"
 
 # Redis Configuration
-redis.host=localhost
-redis.port=6379
-redis.maxConnections=128
+# Disabled by default.
+redis.host = "localhost"
+redis.port = 6379
+redis.maxConnections = 128
+redis.enable = false
 
 #Condition to enable publish locally
 content.publish_task.enabled=true
@@ -653,13 +655,13 @@ cassandra.lp.consistency.level=QUORUM
 content.nested.fields="badgeAssertions,targets,badgeAssociations"
 
 content.cache.ttl=86400
-content.cache.enable=true
-collection.cache.enable=true
+content.cache.enable = false
+collection.cache.enable = false
 content.discard.status=["Draft","FlagDraft"]
 
 framework.categories_cached=["subject", "medium", "gradeLevel", "board"]
 framework.cache.ttl=86400
-framework.cache.read=true
+framework.cache.read = false
 
 
 # Max size(width/height) of thumbnail in pixels

--- a/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/health/HealthCheckManager.scala
+++ b/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/health/HealthCheckManager.scala
@@ -60,10 +60,12 @@ object HealthCheckManager extends CassandraConnector with RedisConnector {
     }
 
     private def checkRedisHealth(): Map[String, Any] = {
+        if (!isEnabled)
+            return Map("name" -> redisLabel, "healthy" -> true, "msg" -> "Redis not configured — skipped")
         try {
             val jedis = getConnection
-            jedis.close()
-            generateCheck(true, redisLabel)
+            if (null != jedis) { jedis.close(); generateCheck(true, redisLabel) }
+            else generateCheck(false, redisLabel)
         } catch {
             case e: Exception => generateCheck(false, redisLabel)
         }

--- a/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/schema/validator/FrameworkValidator.scala
+++ b/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/schema/validator/FrameworkValidator.scala
@@ -32,46 +32,71 @@ trait FrameworkValidator extends IDefinition {
       val targetFwTerms = orgAndTargetTouple._2
       val masterCategories = orgAndTargetTouple._3
 
-      validateAndSetMultiFrameworks(node, orgFwTerms, targetFwTerms, masterCategories).map(_ => {
+      validateAndSetMultiFrameworks(node, orgFwTerms, targetFwTerms, masterCategories).flatMap(_ => {
         val framework: String = node.getMetadata.getOrDefault("framework", "").asInstanceOf[String]
         if (null != fwCategories && fwCategories.nonEmpty && framework.nonEmpty) {
-          //prepare data for validation
           val fwMetadata: Map[String, AnyRef] = node.getMetadata.asScala.filter(entry => fwCategories.contains(entry._1)).toMap
-          //validate data from cache
           if (fwMetadata.nonEmpty) {
-            val errors: util.List[String] = new util.ArrayList[String]
-            for (cat: String <- fwMetadata.keys) {
-              val value: AnyRef = fwMetadata.get(cat).get
-              //TODO: Replace Cache Call With FrameworkCache Implementation
+            Future.sequence(fwMetadata.keys.map { cat =>
+              val value: AnyRef = fwMetadata(cat)
               val cacheKey = "cat_" + framework + cat
-              val list: List[String] = RedisCache.getList(cacheKey)
-              val result: Boolean = value match {
-                case value: String => list.contains(value)
-                case value: util.List[String] => list.asJava.containsAll(value)
-                case value: Array[String] => value.forall(term => list.contains(term))
-                case _ => throw new ClientException("CLIENT_ERROR", "Validation Errors.", util.Arrays.asList("Please provide correct value for [" + cat + "]"))
-              }
-
-              if (!result) {
-                if (list.isEmpty) {
-                  errors.add(cat + " range data is empty from the given framework.")
-                } else {
-                  errors.add("Metadata " + cat + " should belong from:" + list.asJava)
+              val redisEnabled = Platform.getBoolean("redis.enable", false)
+              val cachedList: List[String] = if (redisEnabled) RedisCache.getList(cacheKey) else List()
+              val termsFuture: Future[List[String]] =
+                if (cachedList.nonEmpty) Future.successful(cachedList)
+                else getCategoryTermsFromDB(graphId, framework, cat).map { terms =>
+                  if (terms.nonEmpty && redisEnabled)
+                    RedisCache.saveList(cacheKey, terms)
+                  terms
                 }
+              termsFuture.map { list =>
+                val result: Boolean = value match {
+                  case v: String            => list.contains(v)
+                  case v: util.List[String] => list.asJava.containsAll(v)
+                  case v: Array[String]     => v.forall(list.contains)
+                  case _ => throw new ClientException("CLIENT_ERROR", "Validation Errors.",
+                      util.Arrays.asList("Please provide correct value for [" + cat + "]"))
+                }
+                if (!result) {
+                  if (list.isEmpty) cat + " range data is empty from the given framework."
+                  else "Metadata " + cat + " should belong from:" + list.asJava
+                } else ""
               }
+            }.toList).flatMap { errorList =>
+              val errors = errorList.filter(_.nonEmpty)
+              if (errors.nonEmpty)
+                throw new ClientException("CLIENT_ERROR", "Validation Errors.", errors.asJava)
+              super.validate(node, operation)
             }
-            if (!errors.isEmpty)
-              throw new ClientException("CLIENT_ERROR", "Validation Errors.", errors)
-          }
-        }
-        super.validate(node, operation)
-      }).flatten
+          } else super.validate(node, operation)
+        } else super.validate(node, operation)
+      })
     }).flatten
+  }
+
+  private def getCategoryTermsFromDB(
+      graphId: String, framework: String, category: String
+  )(implicit ec: ExecutionContext, oec: OntologyEngineContext): Future[List[String]] = {
+    val mc = MetadataCriterion.create(new util.ArrayList[Filter]() {{
+      add(new Filter(SystemProperties.IL_FUNC_OBJECT_TYPE.name(), SearchConditions.OP_EQUAL, "Term"))
+      add(new Filter(SystemProperties.IL_SYS_NODE_TYPE.name(), SearchConditions.OP_EQUAL, "DATA_NODE"))
+      add(new Filter("category", SearchConditions.OP_EQUAL, category))
+      add(new Filter("status", SearchConditions.OP_NOT_EQUAL, "Retired"))
+    }})
+    val criteria = new SearchCriteria {{ addMetadata(mc); setCountQuery(false) }}
+    oec.graphService.getNodeByUniqueIds(graphId, criteria).map { nodes =>
+      nodes.asScala.filter { n =>
+        val id = n.getIdentifier
+        id != null && id.toLowerCase.startsWith(framework.toLowerCase + "_")
+      }.flatMap { n =>
+        Option(n.getMetadata.get("name")).map(_.asInstanceOf[String])
+      }.toList
+    }
   }
 
   private def validateAndSetMultiFrameworks(node: Node, orgFwTerms: List[String], targetFwTerms: List[String], masterCategories: List[Map[String, AnyRef]])(implicit ec: ExecutionContext, oec: OntologyEngineContext): Future[Map[String, AnyRef]] = {
     getValidatedTerms(node, orgFwTerms).map(orgTermMap => {
-     val jsonPropsType = schemaValidator.getAllPropsType.asScala 
+     val jsonPropsType = schemaValidator.getAllPropsType.asScala
      masterCategories.map(masterCategory => {
       val orgIdFieldName = masterCategory.getOrElse("orgIdFieldName", "").asInstanceOf[String]
       val code = masterCategory.getOrElse("code", "").asInstanceOf[String]
@@ -183,7 +208,8 @@ trait FrameworkValidator extends IDefinition {
           setCountQuery(false)
         }
       }
-      oec.graphService.getNodeByUniqueIds(node.getGraphId, searchCriteria).map(nodeList => {
+      val graphId = if (StringUtils.isNotBlank(node.getGraphId)) node.getGraphId else "domain"
+      oec.graphService.getNodeByUniqueIds(graphId, searchCriteria).map(nodeList => {
         if (CollectionUtils.isEmpty(nodeList))
           throw new ResourceNotFoundException("ERR_VALIDATING_CONTENT_FRAMEWORK", s"Nodes not found for Id's $ids ")
         val termMap = nodeList.asScala.map(node => node.getIdentifier -> node.getMetadata.getOrDefault("name", "")).toMap

--- a/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/schema/validator/FrameworkValidator.scala
+++ b/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/schema/validator/FrameworkValidator.scala
@@ -66,10 +66,10 @@ trait FrameworkValidator extends IDefinition {
               val errors = errorList.filter(_.nonEmpty)
               if (errors.nonEmpty)
                 throw new ClientException("CLIENT_ERROR", "Validation Errors.", errors.asJava)
-              super.validate(node, operation)
+              super.validate(node, operation, setDefaultValue)
             }
-          } else super.validate(node, operation)
-        } else super.validate(node, operation)
+          } else super.validate(node, operation, setDefaultValue)
+        } else super.validate(node, operation, setDefaultValue)
       })
     }).flatten
   }

--- a/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/schema/validator/PropAsEdgeValidator.scala
+++ b/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/schema/validator/PropAsEdgeValidator.scala
@@ -2,13 +2,16 @@ package org.sunbird.graph.schema.validator
 
 import org.apache.commons.collections4.CollectionUtils
 import org.sunbird.cache.impl.RedisCache
+import org.sunbird.common.Platform
 import org.sunbird.common.exception.ClientException
 import org.sunbird.graph.OntologyEngineContext
-import org.sunbird.graph.dac.model.Node
+import org.sunbird.graph.dac.model.{Filter, MetadataCriterion, Node, SearchConditions, SearchCriteria}
+import org.sunbird.graph.common.enums.SystemProperties
 import org.sunbird.graph.schema.IDefinition
 
 import scala.collection.convert.ImplicitConversions._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 
 trait PropAsEdgeValidator extends IDefinition {
 
@@ -16,31 +19,56 @@ trait PropAsEdgeValidator extends IDefinition {
     val prefix = "edge_"
 
     @throws[Exception]
-    abstract override def validate(node: Node, operation: String, setDefaultValue: Boolean)(implicit ec: ExecutionContext, oec:OntologyEngineContext): Future[Node] = {
+    abstract override def validate(node: Node, operation: String, setDefaultValue: Boolean)(implicit ec: ExecutionContext, oec: OntologyEngineContext): Future[Node] = {
         if (schemaValidator.getConfig.hasPath(edgePropsKey)) {
             val keys = CollectionUtils.intersection(node.getMetadata.keySet(), schemaValidator.getConfig.getObject(edgePropsKey).keySet())
             if (!keys.isEmpty) {
-                keys.toArray().toStream.map(key => {
-                    val cacheKey = prefix + schemaValidator.getConfig.getString(edgePropsKey + "." + key).toLowerCase
-                    val list = RedisCache.getList(cacheKey)
-                    if (CollectionUtils.isNotEmpty(list)) {
+                Future.sequence(keys.toArray().toList.map { key =>
+                    val objectType = schemaValidator.getConfig.getString(edgePropsKey + "." + key.toString)
+                    val cacheKey = prefix + objectType.toLowerCase
+                    val cachedList: List[String] = if (Platform.getBoolean("redis.enable", false))
+                        RedisCache.getList(cacheKey) else List()
+                    val resolvedGraphId = if (org.apache.commons.lang3.StringUtils.isNotBlank(node.getGraphId)) node.getGraphId else "domain"
+                    val listFuture: Future[List[String]] =
+                        if (cachedList.nonEmpty) Future.successful(cachedList)
+                        else getEdgeListFromDB(resolvedGraphId, objectType).map { list =>
+                            if (list.nonEmpty && Platform.getBoolean("redis.enable", false))
+                                RedisCache.saveList(cacheKey, list)
+                            list
+                        }
+                    listFuture.map { list =>
+                        if (list.isEmpty)
+                            throw new ClientException("ERR_EMPTY_EDGE_PROPERTY_LIST", "The list to validate input is empty.")
                         val value = node.getMetadata.get(key)
                         if (value.isInstanceOf[String]) {
-                            if(!list.contains(value.asInstanceOf[String]))
+                            if (!list.contains(value.asInstanceOf[String]))
                                 throw new ClientException("ERR_INVALID_EDGE_PROPERTY", key + " value should be one of " + list)
                         } else if (value.isInstanceOf[java.util.List[AnyRef]]) {
-                            val filteredSize = value.asInstanceOf[java.util.List[AnyRef]].toList.filter(e => list.contains(e)).size
-                            if(filteredSize != value.asInstanceOf[java.util.List[AnyRef]].size)
+                            val filteredSize = value.asInstanceOf[java.util.List[AnyRef]].toList.count(e => list.contains(e))
+                            if (filteredSize != value.asInstanceOf[java.util.List[AnyRef]].size)
                                 throw new ClientException("ERR_INVALID_EDGE_PROPERTY", key + " value should be any of " + list)
                         } else {
                             throw new ClientException("ERR_INVALID_EDGE_PROPERTY", key + " given datatype is invalid.")
                         }
-                    } else {
-                        throw new ClientException("ERR_EMPTY_EDGE_PROPERTY_LIST", "The list to validate input is empty.")
                     }
-                })
-            }
+                }).flatMap(_ => super.validate(node, operation))
+            } else super.validate(node, operation)
+        } else super.validate(node, operation)
+    }
+
+    private def getEdgeListFromDB(
+        graphId: String, objectType: String
+    )(implicit ec: ExecutionContext, oec: OntologyEngineContext): Future[List[String]] = {
+        val mc = MetadataCriterion.create(new java.util.ArrayList[Filter]() {{
+            add(new Filter(SystemProperties.IL_FUNC_OBJECT_TYPE.name(), SearchConditions.OP_EQUAL, objectType))
+            add(new Filter(SystemProperties.IL_SYS_NODE_TYPE.name(), SearchConditions.OP_EQUAL, "DATA_NODE"))
+            add(new Filter("status", SearchConditions.OP_EQUAL, "Live"))
+        }})
+        val criteria = new SearchCriteria {{ addMetadata(mc); setCountQuery(false) }}
+        oec.graphService.getNodeByUniqueIds(graphId, criteria).map { nodes =>
+            nodes.asScala.flatMap { n =>
+                Option(n.getMetadata.get("name")).map(_.asInstanceOf[String])
+            }.toList
         }
-        super.validate(node, operation)
     }
 }

--- a/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/schema/validator/PropAsEdgeValidator.scala
+++ b/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/schema/validator/PropAsEdgeValidator.scala
@@ -51,9 +51,9 @@ trait PropAsEdgeValidator extends IDefinition {
                             throw new ClientException("ERR_INVALID_EDGE_PROPERTY", key + " given datatype is invalid.")
                         }
                     }
-                }).flatMap(_ => super.validate(node, operation))
-            } else super.validate(node, operation)
-        } else super.validate(node, operation)
+                }).flatMap(_ => super.validate(node, operation, setDefaultValue))
+            } else super.validate(node, operation, setDefaultValue)
+        } else super.validate(node, operation, setDefaultValue)
     }
 
     private def getEdgeListFromDB(

--- a/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/schema/validator/VersioningNode.scala
+++ b/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/schema/validator/VersioningNode.scala
@@ -131,17 +131,21 @@ trait VersioningNode extends IDefinition {
     }
 
     def getCachedNode(identifier: String, ttl: Integer)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Node] = {
-        val nodeStringFuture: Future[String] = RedisCache.getAsync(identifier, nodeCacheAsyncHandler, ttl)
-        nodeStringFuture.map(nodeString => {
-            if (null != nodeString && !nodeString.asInstanceOf[String].isEmpty) {
-                val nodeMap: util.Map[String, AnyRef] = JsonUtils.deserialize(nodeString.asInstanceOf[String], classOf[java.util.Map[String, AnyRef]])
-                val node: Node = NodeUtil.deserialize(nodeMap, getSchemaName(), schemaValidator.getConfig
-                  .getAnyRef("relations").asInstanceOf[java.util.Map[String, AnyRef]])
-                Future {node}
-            } else {
-                super.getNode(identifier, "read", null)
-            }
-        }).flatten
+        if (!Platform.getBoolean("redis.enable", false)) {
+            super.getNode(identifier, "read", null)
+        } else {
+            val nodeStringFuture: Future[String] = RedisCache.getAsync(identifier, nodeCacheAsyncHandler, ttl)
+            nodeStringFuture.map(nodeString => {
+                if (null != nodeString && !nodeString.asInstanceOf[String].isEmpty) {
+                    val nodeMap: util.Map[String, AnyRef] = JsonUtils.deserialize(nodeString.asInstanceOf[String], classOf[java.util.Map[String, AnyRef]])
+                    val node: Node = NodeUtil.deserialize(nodeMap, getSchemaName(), schemaValidator.getConfig
+                      .getAnyRef("relations").asInstanceOf[java.util.Map[String, AnyRef]])
+                    Future {node}
+                } else {
+                    super.getNode(identifier, "read", null)
+                }
+            }).flatten
+        }
     }
 
     private def nodeCacheAsyncHandler(objKey: String)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[String] = {

--- a/platform-core/platform-cache/src/main/scala/org/sunbird/cache/impl/RedisCache.scala
+++ b/platform-core/platform-cache/src/main/scala/org/sunbird/cache/impl/RedisCache.scala
@@ -14,7 +14,14 @@ import scala.jdk.CollectionConverters._
 object RedisCache extends RedisConnector {
 
 	private val logger: Logger = LoggerFactory.getLogger(RedisCache.getClass.getCanonicalName)
-	private val isRedisEnabled = if (Platform.config.hasPath("redis.enable")) Platform.config.getBoolean("redis.enable") else true
+	private val isRedisEnabled = Platform.getBoolean("redis.enable", false)
+
+	if (isRedisEnabled)
+		logger.info("RedisCache initialized — Redis ENABLED ({}:{})",
+			Platform.getString("redis.host", "localhost"),
+			Platform.getInteger("redis.port", 6379).toString)
+	else
+		logger.info("RedisCache initialized — Redis DISABLED. All reads fall back to primary DB; writes are no-ops.")
 
 	/**
 	 * This method store string data into cache for given Key

--- a/platform-core/platform-cache/src/main/scala/org/sunbird/cache/util/RedisConnector.scala
+++ b/platform-core/platform-cache/src/main/scala/org/sunbird/cache/util/RedisConnector.scala
@@ -15,9 +15,17 @@ trait RedisConnector {
 	private val INDEX = Platform.getInteger("redis.dbIndex", 0)
 	protected val isEnabled: Boolean = Platform.getBoolean("redis.enable", false)
 
-	private lazy val jedisPool: JedisPool = {
-		TelemetryManager.info("Initializing Redis connection pool at " + HOST + ":" + PORT)
-		new JedisPool(getConfig(), HOST, PORT)
+	@volatile private var jedisPoolOpt: Option[JedisPool] = None
+
+	private def jedisPool: JedisPool = this.synchronized {
+		jedisPoolOpt match {
+			case Some(pool) => pool
+			case None =>
+				TelemetryManager.info("Initializing Redis connection pool at " + HOST + ":" + PORT)
+				val pool = new JedisPool(getConfig(), HOST, PORT)
+				jedisPoolOpt = Some(pool)
+				pool
+		}
 	}
 
 	registerShutdownHook()
@@ -54,11 +62,16 @@ trait RedisConnector {
 	 * Called automatically via the JVM shutdown hook.
 	 */
 	def closePool(): Unit = {
-		if (isEnabled && jedisPool != null && !jedisPool.isClosed) {
-			try jedisPool.close()
-			catch {
-				case e: Exception => TelemetryManager.error("Error closing JedisPool: " + e.getMessage, e)
+		if (isEnabled) {
+			jedisPoolOpt.foreach { pool =>
+				if (!pool.isClosed) {
+					try pool.close()
+					catch {
+						case e: Exception => TelemetryManager.error("Error closing JedisPool: " + e.getMessage, e)
+					}
+				}
 			}
+			jedisPoolOpt = None
 		}
 	}
 

--- a/platform-core/platform-cache/src/main/scala/org/sunbird/cache/util/RedisConnector.scala
+++ b/platform-core/platform-cache/src/main/scala/org/sunbird/cache/util/RedisConnector.scala
@@ -13,7 +13,12 @@ trait RedisConnector {
 	private val PORT = Platform.getInteger("redis.port", 6379)
 	private val MAX_CONNECTIONS = Platform.getInteger("redis.maxConnections", 128)
 	private val INDEX = Platform.getInteger("redis.dbIndex", 0)
-	private val jedisPool: JedisPool = new JedisPool(getConfig(), HOST, PORT)
+	protected val isEnabled: Boolean = Platform.getBoolean("redis.enable", false)
+
+	private lazy val jedisPool: JedisPool = {
+		TelemetryManager.info("Initializing Redis connection pool at " + HOST + ":" + PORT)
+		new JedisPool(getConfig(), HOST, PORT)
+	}
 
 	registerShutdownHook()
 
@@ -22,12 +27,10 @@ trait RedisConnector {
 	 *
 	 * @return Jedis Object
 	 */
-	protected def getConnection: Jedis = try {
+	protected def getConnection: Jedis = if (!isEnabled) null else {
 		val jedis = jedisPool.getResource
 		if (INDEX > 0) jedis.select(INDEX)
 		jedis
-	} catch {
-		case e: Exception => throw e
 	}
 
 	/**
@@ -51,7 +54,7 @@ trait RedisConnector {
 	 * Called automatically via the JVM shutdown hook.
 	 */
 	def closePool(): Unit = {
-		if (jedisPool != null && !jedisPool.isClosed) {
+		if (isEnabled && jedisPool != null && !jedisPool.isClosed) {
 			try jedisPool.close()
 			catch {
 				case e: Exception => TelemetryManager.error("Error closing JedisPool: " + e.getMessage, e)
@@ -60,7 +63,7 @@ trait RedisConnector {
 	}
 
 	private def registerShutdownHook(): Unit = {
-		Runtime.getRuntime.addShutdownHook(new Thread(() => {
+		if (isEnabled) Runtime.getRuntime.addShutdownHook(new Thread(() => {
 			TelemetryManager.log("Shutting down RedisConnector — closing connection pool")
 			closePool()
 		}))

--- a/search-api/search-service/conf/application.conf
+++ b/search-api/search-service/conf/application.conf
@@ -328,3 +328,6 @@ cloud_storage_auth_type="ACCESS_KEY"
 cloud_storage_key=""
 cloud_storage_secret=""
 cloud_storage_container=""
+# Redis Configuration
+# Redis is not currently used by search-api. cache.type="redis" above is a legacy dead key.
+redis.enable = false

--- a/taxonomy-api/taxonomy-actors/src/test/resources/application.conf
+++ b/taxonomy-api/taxonomy-actors/src/test/resources/application.conf
@@ -287,6 +287,7 @@ cassandra.lpa.connection="127.0.0.1:9042,127.0.0.2:9042,127.0.0.3:9042"
 redis.host=localhost
 redis.port=6379
 redis.maxConnections=128
+redis.enable = false
 
 #Condition to enable publish locally
 content.publish_task.enabled=true

--- a/taxonomy-api/taxonomy-service/conf/application.conf
+++ b/taxonomy-api/taxonomy-service/conf/application.conf
@@ -331,9 +331,19 @@ cloudstorage.metadata.list=["appIcon","posterImage","artifactUrl","downloadUrl",
 
 framework.keyspace="dev_hierarchy_store"
 framework.hierarchy.table="framework_hierarchy"
+# Redis Configuration
+# Disabled by default. Set REDIS_ENABLE=true to activate caching.
+# When disabled, all data is read directly from the graph database on every request.
+redis.host = "localhost"
+redis.port = 6379
+redis.maxConnections = 128
+redis.dbIndex = 0
+redis.enable = false
+
+# Framework caching (requires redis.enable=true to have effect)
 framework.categories_cached=["subject", "medium", "gradeLevel", "board"]
-framework.cache.ttl=86400
-framework.cache.read=true
+framework.cache.ttl = 86400
+framework.cache.read = false
 
 lock.keyspace = "lock_db"
 defaultLockExpiryTime = 3600

--- a/taxonomy-api/taxonomy-service/conf/application.conf
+++ b/taxonomy-api/taxonomy-service/conf/application.conf
@@ -332,7 +332,7 @@ cloudstorage.metadata.list=["appIcon","posterImage","artifactUrl","downloadUrl",
 framework.keyspace="dev_hierarchy_store"
 framework.hierarchy.table="framework_hierarchy"
 # Redis Configuration
-# Disabled by default. Set REDIS_ENABLE=true to activate caching.
+# Disabled by default. Set redis.enable=true (in this file or via a config override) to activate caching.
 # When disabled, all data is read directly from the graph database on every request.
 redis.host = "localhost"
 redis.port = 6379


### PR DESCRIPTION
## Summary

Redis was previously a hard dependency across all Knowledge Platform services.
The connection pool was eagerly initialized on startup regardless of config,
and all cache reads were unconditional — causing startup failures and
`INVALID_GRAPH` / `NullPointerException` errors in environments where Redis
is not available or not yet provisioned.

This PR makes Redis fully optional via a single flag: `redis.enable = false`.
When disabled, all cache layers transparently fall back to the primary data
stores (JanusGraph / Cassandra) with no functional regression.

## Changes

### Core Redis Infrastructure (`platform-core`)
- `RedisConnector`: made `jedisPool` **lazy** — pool is never created when Redis is disabled; `getConnection` returns `null`; shutdown hook and `closePool` are guarded by `isEnabled`
- `RedisCache`: changed `isRedisEnabled` default from `true` → `false`; added startup log clearly stating enabled/disabled status and host:port

### Validators (`ontology-engine`)
- `FrameworkValidator`: replaced synchronous Redis-only category term lookup with an **async cache-aside pattern** — reads from Redis when enabled, falls back to graph DB otherwise; also fixed a null-safe `graphId` resolution in `getValidatedTerms` that caused `INVALID_GRAPH` errors on `visibility=Parent` nodes deserialized from Cassandra hierarchy
- `PropAsEdgeValidator`: same cache-aside refactor — added `getEdgeListFromDB` fallback; fixed null-safe `graphId` resolution
- `VersioningNode`: `getCachedNode` short-circuits to DB when `redis.enable=false`

### Bug Fix (`content-api`)
- `UpdateHierarchyManager.addNodeToList`: fixed `INVALID_GRAPH` crash on hierarchy update — `visibility=Parent` nodes built from existing Cassandra hierarchy were deserialized via `NodeUtil.deserialize` which never sets `graphId`; added `node.setGraphId("domain")` after deserialization
- `HierarchyManager.getPublishedHierarchy`: Redis read now gated on `collection.cache.enable` flag

### Health Check (`ontology-engine`)
- `HealthCheckManager`: Redis health check returns `healthy=true` with a "skipped" message when `redis.enable=false`, preventing spurious health failures

### Configuration (all services)
- Added `redis.enable = false` as explicit default in all `application.conf` files and test configs
- Set `content.cache.enable`, `collection.cache.enable`, `framework.cache.read` to `false` — caching is now **opt-in**

## Behaviour

| `redis.enable` | Cache reads | Cache writes | Pool init |
|---|---|---|---|
| `false` (default) | Skip → read from DB | No-op | Never |
| `true` | Redis → DB fallback | Write to Redis | On startup |

## Test Plan
- [ ] Verify all services start cleanly with `redis.enable = false` (no Redis running)
- [ ] Verify hierarchy update (`PATCH /content/v3/hierarchy/update`) works without Redis
- [ ] Verify framework validation works without Redis (reads from graph DB)
- [ ] Verify content read still works without Redis (falls back to JanusGraph)
- [ ] Verify `/health` endpoint returns healthy when Redis is disabled
- [ ] Verify all unit tests pass (`mvn test`)
- [ ] Verify caching works correctly when `redis.enable = true` with Redis running
