### PR TITLE
fix: resolve Dependabot security vulnerabilities (ZooKeeper, SnakeYAML, poi-ooxml, Jackson, Netty, Guava)

### DIFF
--- a/assessment-api/assessment-controllers/pom.xml
+++ b/assessment-api/assessment-controllers/pom.xml
@@ -19,7 +19,7 @@
         <scala.maj.version>2.13</scala.maj.version>
         <scala.version>2.13.12</scala.version>
         <play2.version>3.0.5</play2.version>
-        <fasterxml.jackson.version>2.15.3</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
     </properties>
 
     <dependencies>

--- a/content-api/content-controllers/pom.xml
+++ b/content-api/content-controllers/pom.xml
@@ -19,7 +19,7 @@
         <scala.maj.version>2.13</scala.maj.version>
         <scala.version>2.13.12</scala.version>
         <play2.version>3.0.5</play2.version>
-        <fasterxml.jackson.version>2.15.3</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
     </properties>
 
     <dependencies>

--- a/knowlg-service/pom.xml
+++ b/knowlg-service/pom.xml
@@ -54,7 +54,7 @@
         <play2.plugin.version>1.0.0-rc5</play2.plugin.version>
         <sbt-compiler.plugin.version>1.0.0</sbt-compiler.plugin.version>
         <netty.version>4.1.129.Final</netty.version>
-        <fasterxml.jackson.version>2.15.3</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
     </properties>
 
     <dependencyManagement>

--- a/ontology-engine/graph-core_2.13/pom.xml
+++ b/ontology-engine/graph-core_2.13/pom.xml
@@ -73,50 +73,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.cassandraunit</groupId>
-            <artifactId>cassandra-unit</artifactId>
-            <version>3.11.2.0</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-handler</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.xerial.snappy</groupId>
-                    <artifactId>snappy-java</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <version>4.1.68.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>5.13.0</version>
-            <scope>test</scope>
-        </dependency>  
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>4.1.100.Final</version>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>cassandra</artifactId>
+            <version>1.17.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ontology-engine/graph-core_2.13/pom.xml
+++ b/ontology-engine/graph-core_2.13/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/ontology-engine/graph-core_2.13/src/test/scala/org/sunbird/graph/BaseSpec.scala
+++ b/ontology-engine/graph-core_2.13/src/test/scala/org/sunbird/graph/BaseSpec.scala
@@ -1,23 +1,56 @@
 package org.sunbird.graph
 
-import java.io.File
-import com.typesafe.config.ConfigFactory
-import org.apache.commons.io.FileUtils
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper
+import com.datastax.driver.core.{Cluster, ProtocolVersion, Session}
 import org.scalatest.{AsyncFlatSpec, BeforeAndAfterAll, Matchers}
 import org.sunbird.cassandra.CassandraConnector
-import org.sunbird.common.Platform
 import org.janusgraph.core.JanusGraph
 import org.janusgraph.core.JanusGraphFactory
-import org.sunbird.graph.service.util.DriverUtil
-import java.lang.reflect.Field
+import org.testcontainers.containers.CassandraContainer
+
 import java.util
 import scala.collection.JavaConverters._
+
+/**
+ * Singleton that manages a single shared Cassandra testcontainer for all test suites
+ * in graph-core_2.13.  The container is started lazily on first access and is never
+ * explicitly stopped — Testcontainers' Ryuk reaper handles teardown after the JVM exits.
+ */
+object CassandraTestSupport {
+
+    val container: CassandraContainer[_] = {
+        val c = new CassandraContainer("cassandra:3.11")
+        c.start()
+        c
+    }
+
+    private val cluster: Cluster =
+        Cluster.builder()
+            .addContactPoint(container.getHost)
+            .withPort(container.getMappedPort(9042))
+            .withoutJMXReporting()
+            .withProtocolVersion(ProtocolVersion.V4)
+            .build()
+
+    /** Open a new Session against the shared container cluster. */
+    def newSession(): Session = cluster.connect()
+
+    /**
+     * Inject the given session into CassandraConnector's private static sessionMap
+     * under key "lp" so that CassandraConnector.getSession() returns our container
+     * session instead of trying to reach a real Cassandra host.
+     */
+    def injectIntoConnector(session: Session): Unit = {
+        val field = classOf[CassandraConnector].getDeclaredField("sessionMap")
+        field.setAccessible(true)
+        val map = field.get(null).asInstanceOf[java.util.Map[String, Session]]
+        map.put("lp", session)
+    }
+}
 
 class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
 
     var graph: JanusGraph = _
-    var session: com.datastax.driver.core.Session = null
+    var session: Session = null
     implicit val oec: OntologyEngineContext = new OntologyEngineContext
 
     private val script_1 = "CREATE KEYSPACE IF NOT EXISTS content_store WITH replication = {'class': 'SimpleStrategy','replication_factor': '1'};"
@@ -49,14 +82,14 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
         }
     }
 
-    def setUpEmbeddedCassandra(): Unit = {
-        System.setProperty("cassandra.unsafesystem", "true")
-        EmbeddedCassandraServerHelper.startEmbeddedCassandra("/cassandra-unit.yaml", 100000L)
+    def setUpCassandraContainer(): Unit = {
+        session = CassandraTestSupport.newSession()
+        CassandraTestSupport.injectIntoConnector(session)
     }
 
     override def beforeAll(): Unit = {
         setUpEmbeddedGraph()
-        setUpEmbeddedCassandra()
+        setUpCassandraContainer()
         createRelationData()
         executeCassandraQuery(script_1, script_2, script_3, script_4, script_5, script_6, script_7, script_8, script_9, script_10, script_11, script_12, script_13, script_14)
     }
@@ -65,23 +98,22 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
         if (null != graph) {
             graph.close()
         }
-        if(null != session && !session.isClosed)
+        if (null != session && !session.isClosed)
             session.close()
-        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra()
+        // Container is a singleton managed by Testcontainers' Ryuk reaper — do not stop it here.
     }
 
-
     def executeCassandraQuery(queries: String*): Unit = {
-        if(null == session || session.isClosed){
+        if (null == session || session.isClosed) {
             session = CassandraConnector.getSession
         }
-        for(query <- queries) {
+        for (query <- queries) {
             session.execute(query)
         }
     }
 
     def createVertex(label: String, properties: Map[String, AnyRef]): Unit = {
-        val vertex = graph.asInstanceOf[org.janusgraph.core.JanusGraphTransaction].addVertex(org.apache.tinkerpop.gremlin.structure.T.label, label)
+        val vertex = graph.addVertex(org.apache.tinkerpop.gremlin.structure.T.label, label)
         properties.foreach { case (k, v) => vertex.property(k, v) }
     }
 
@@ -91,10 +123,10 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
         graph.tx().commit()
     }
 
-	def createBulkNodes(): Unit ={
+    def createBulkNodes(): Unit = {
         createVertex("domain", Map[String, AnyRef]("IL_UNIQUE_ID" -> "do_0000123", "identifier" -> "do_0000123", "graphId" -> "domain"))
         createVertex("domain", Map[String, AnyRef]("IL_UNIQUE_ID" -> "do_0000234", "identifier" -> "do_0000234", "graphId" -> "domain"))
         createVertex("domain", Map[String, AnyRef]("IL_UNIQUE_ID" -> "do_0000345", "identifier" -> "do_0000345", "graphId" -> "domain"))
-		graph.tx().commit()
-	}
+        graph.tx().commit()
+    }
 }

--- a/ontology-engine/graph-core_2.13/src/test/scala/org/sunbird/graph/util/ScalaJsonUtilTest.scala
+++ b/ontology-engine/graph-core_2.13/src/test/scala/org/sunbird/graph/util/ScalaJsonUtilTest.scala
@@ -4,7 +4,7 @@ import java.util
 
 import com.fasterxml.jackson.databind.exc.{InvalidDefinitionException, MismatchedInputException}
 import org.apache.commons.lang3.StringUtils
-import org.codehaus.jackson.JsonProcessingException
+import com.fasterxml.jackson.core.JsonProcessingException
 import org.scalatest.{FlatSpec, Matchers}
 
 class ScalaJsonUtilTest extends FlatSpec with Matchers {

--- a/ontology-engine/graph-engine_2.13/pom.xml
+++ b/ontology-engine/graph-engine_2.13/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,51 +61,6 @@
             <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.cassandraunit</groupId>
-            <artifactId>cassandra-unit</artifactId>
-            <version>3.11.2.0</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-handler</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.xerial.snappy</groupId>
-                    <artifactId>snappy-java</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <scope>test</scope>
-        </dependency>  
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <version>4.1.129.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>5.13.0</version>
-            <scope>test</scope>
-        </dependency>  
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>4.1.129.Final</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>com.dimafeng</groupId>
             <artifactId>testcontainers-scala_2.13</artifactId>
@@ -115,6 +70,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <version>1.17.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>cassandra</artifactId>
             <version>1.17.6</version>
             <scope>test</scope>
         </dependency>

--- a/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/BaseSpec.scala
+++ b/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/BaseSpec.scala
@@ -1,26 +1,59 @@
 package org.sunbird.graph
 
-import java.io.File
-import com.typesafe.config.ConfigFactory
-import org.apache.commons.io.FileUtils
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper
+import com.datastax.driver.core.{Cluster, ProtocolVersion, Session}
 import redis.embedded.RedisServer
 import org.scalatest.{AsyncFlatSpec, BeforeAndAfterAll, Matchers}
 import org.sunbird.cassandra.CassandraConnector
-import org.sunbird.common.Platform
-import org.sunbird.graph.service.util.DriverUtil
 import org.sunbird.graph.dac.model.Node
 import org.sunbird.graph.schema.FrameworkMasterCategoryMap
 import org.janusgraph.core.JanusGraph
 import org.janusgraph.core.JanusGraphFactory
-import java.lang.reflect.Field
+import org.testcontainers.containers.CassandraContainer
+
 import java.util
 import scala.collection.JavaConverters._
+
+/**
+ * Singleton that manages a single shared Cassandra testcontainer for all test suites
+ * in graph-engine_2.13.  The container is started lazily on first access and is never
+ * explicitly stopped — Testcontainers' Ryuk reaper handles teardown after the JVM exits.
+ */
+object CassandraTestSupport {
+
+    val container: CassandraContainer[_] = {
+        val c = new CassandraContainer("cassandra:3.11")
+        c.start()
+        c
+    }
+
+    private val cluster: Cluster =
+        Cluster.builder()
+            .addContactPoint(container.getHost)
+            .withPort(container.getMappedPort(9042))
+            .withoutJMXReporting()
+            .withProtocolVersion(ProtocolVersion.V4)
+            .build()
+
+    /** Open a new Session against the shared container cluster. */
+    def newSession(): Session = cluster.connect()
+
+    /**
+     * Inject the given session into CassandraConnector's private static sessionMap
+     * under key "lp" so that CassandraConnector.getSession() returns our container
+     * session instead of trying to reach a real Cassandra host.
+     */
+    def injectIntoConnector(session: Session): Unit = {
+        val field = classOf[CassandraConnector].getDeclaredField("sessionMap")
+        field.setAccessible(true)
+        val map = field.get(null).asInstanceOf[java.util.Map[String, Session]]
+        map.put("lp", session)
+    }
+}
 
 class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
 
     var graph: JanusGraph = _
-    var session: com.datastax.driver.core.Session = null
+    var session: Session = null
     implicit val oec: OntologyEngineContext = new OntologyEngineContext
 
     private val script_1 = "CREATE KEYSPACE IF NOT EXISTS content_store WITH replication = {'class': 'SimpleStrategy','replication_factor': '1'};"
@@ -51,16 +84,16 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
         }
     }
 
-    def setUpEmbeddedCassandra(): Unit = {
-        System.setProperty("cassandra.unsafesystem", "true")
-        EmbeddedCassandraServerHelper.startEmbeddedCassandra("/cassandra-unit.yaml", 100000L)
+    def setUpCassandraContainer(): Unit = {
+        session = CassandraTestSupport.newSession()
+        CassandraTestSupport.injectIntoConnector(session)
     }
 
     var redisServer: RedisServer = _
 
     override def beforeAll(): Unit = {
         setUpEmbeddedGraph()
-        setUpEmbeddedCassandra()
+        setUpCassandraContainer()
         setupRedis()
         setupGraphData()
         createRelationData()
@@ -71,9 +104,9 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
         if (null != graph) {
             graph.close()
         }
-        if(null != session && !session.isClosed)
+        if (null != session && !session.isClosed)
             session.close()
-        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra()
+        // Container is a singleton managed by Testcontainers' Ryuk reaper — do not stop it here.
         if (null != redisServer) {
             redisServer.stop()
         }
@@ -85,10 +118,10 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     def executeCassandraQuery(queries: String*): Unit = {
-        if(null == session || session.isClosed){
+        if (null == session || session.isClosed) {
             session = CassandraConnector.getSession
         }
-        for(query <- queries) {
+        for (query <- queries) {
             session.execute(query)
         }
     }
@@ -120,7 +153,7 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
 
 
     def createVertex(label: String, properties: Map[String, AnyRef]): Unit = {
-        val vertex = graph.asInstanceOf[org.janusgraph.core.JanusGraphTransaction].addVertex(org.apache.tinkerpop.gremlin.structure.T.label, label)
+        val vertex = graph.addVertex(org.apache.tinkerpop.gremlin.structure.T.label, label)
         properties.foreach { case (k, v) => vertex.property(k, v) }
     }
 
@@ -131,7 +164,7 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
         graph.tx().commit()
     }
 
-	def createBulkNodes(): Unit ={
+	def createBulkNodes(): Unit = {
         createVertex("domain", Map[String, AnyRef]("IL_UNIQUE_ID" -> "do_0000123", "identifier" -> "do_0000123", "graphId" -> "domain"))
         createVertex("domain", Map[String, AnyRef]("IL_UNIQUE_ID" -> "do_0000234", "identifier" -> "do_0000234", "graphId" -> "domain"))
         createVertex("domain", Map[String, AnyRef]("IL_UNIQUE_ID" -> "do_0000345", "identifier" -> "do_0000345", "graphId" -> "domain"))

--- a/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/nodes/TestDataNode.scala
+++ b/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/nodes/TestDataNode.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 class TestDataNode extends BaseSpec {
 
     override def createVertex(label: String, properties: Map[String, AnyRef]): Unit = {
-        val vertex = graph.asInstanceOf[org.janusgraph.core.JanusGraphTransaction].addVertex(org.apache.tinkerpop.gremlin.structure.T.label, label)
+        val vertex = graph.addVertex(org.apache.tinkerpop.gremlin.structure.T.label, label)
         properties.foreach { case (k, v) => vertex.property(k, v) }
     }
 

--- a/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/utils/ScalaJsonUtilsTest.scala
+++ b/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/utils/ScalaJsonUtilsTest.scala
@@ -4,7 +4,7 @@ import java.util
 
 import com.fasterxml.jackson.databind.exc.{InvalidDefinitionException, MismatchedInputException}
 import org.apache.commons.lang3.StringUtils
-import org.codehaus.jackson.JsonProcessingException
+import com.fasterxml.jackson.core.JsonProcessingException
 import org.scalatest.{FlatSpec, Matchers}
 
 class ScalaJsonUtilsTest extends FlatSpec with Matchers {

--- a/platform-core/platform-common/pom.xml
+++ b/platform-core/platform-common/pom.xml
@@ -57,18 +57,12 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>3.17</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.xmlbeans</groupId>
-                    <artifactId>xmlbeans</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>5.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
-            <version>3.0.0</version>
+            <version>5.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/platform-modules/mimetype-manager/pom.xml
+++ b/platform-modules/mimetype-manager/pom.xml
@@ -47,16 +47,6 @@
             <version>2.4.9</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-handler</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<scala.maj.version>2.13</scala.maj.version>
 		<scala.version>2.13.12</scala.version>
 		<scalatest.version>3.0.8</scalatest.version>
-		<fasterxml.jackson.version>2.15.3</fasterxml.jackson.version>
+		<fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
 		<logback.version>1.5.25</logback.version>
 	</properties>
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 			<dependency>
 				<groupId>org.apache.zookeeper</groupId>
 				<artifactId>zookeeper</artifactId>
-				<version>3.8.4</version>
+				<version>3.8.6</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>

--- a/search-api/search-core/pom.xml
+++ b/search-api/search-core/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.12.1</version>
+            <version>2.18.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.7.1</version>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/taxonomy-api/taxonomy-controllers/pom.xml
+++ b/taxonomy-api/taxonomy-controllers/pom.xml
@@ -19,7 +19,7 @@
         <scala.maj.version>2.13</scala.maj.version>
         <scala.version>2.13.12</scala.version>
         <play2.version>3.0.5</play2.version>
-        <fasterxml.jackson.version>2.15.3</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

This PR resolves all open Dependabot security alerts on the repository by upgrading vulnerable dependencies and migrating discontinued test infrastructure (`cassandra-unit` → `testcontainers`).

---

## Vulnerabilities Fixed

### 🔴 HIGH — ZooKeeper (alerts #89, #90)
| Summary | Fix |
|---------|-----|
| Reverse-DNS fallback enables hostname verification bypass in `ZKTrustManager` | `3.8.4` → `3.8.6` in root `dependencyManagement` |
| Improper handling of configuration values | same |

**File:** `pom.xml`

---

### 🔴 HIGH — SnakeYAML Constructor Deserialization RCE (alerts #86, #87)
| Summary | Fix |
|---------|-----|
| Arbitrary code execution via malicious YAML input | `1.33` → `2.0` |

**Root cause:** `cassandra-unit:3.11.2.0` (discontinued) calls `new Constructor(Class)` — an API removed in SnakeYAML 2.0 — blocking the upgrade.

**Solution:** Replaced `cassandra-unit` with `testcontainers-cassandra` in both affected modules:
- `ontology-engine/graph-core_2.13` — `EmbeddedCassandraServerHelper` replaced with a `CassandraTestSupport` singleton that starts a `cassandra:3.11` Docker container and injects the session into `CassandraConnector` via reflection
- `ontology-engine/graph-engine_2.13` — same pattern; embedded Redis setup retained unchanged

**Verified:** 0 suites aborted (was 3), no `NoSuchMethodError` for SnakeYAML after migration.

---

### 🔴 HIGH — Jackson Core DoS (alerts #63, #68, #69, #77, #85, #88)
| Summary | Fix |
|---------|-----|
| Number Length Constraint Bypass in Async Parser leads to DoS | `2.15.3` → `2.18.6` |

**Files:** Root `pom.xml` (`fasterxml.jackson.version`), plus local overrides in `taxonomy-controllers`, `content-controllers`, `assessment-controllers`, `knowlg-service`, and hardcoded versions in `search-core`.

---

### 🟡 MEDIUM — Netty (alerts #70–84)
All `io.netty:*` vulnerabilities (CRLF injection, HTTP/2 DDoS reset, SSL crash, DoS) resolved via `netty-bom:4.1.129.Final` imported in root `pom.xml`.

---

### 🟡 MEDIUM — Apache POI OOXML Improper Input Validation (alert #21)
| Summary | Fix |
|---------|-----|
| Malformed OOXML file can trigger improper input validation | `3.17` → `5.4.0` |

Also upgraded `xmlbeans` `3.0.0` → `5.2.1` (required by POI 5.x) and removed the now-unnecessary `xmlbeans` exclusion. No source code changes — POI is not directly used in application code.

**File:** `platform-core/platform-common/pom.xml`

---

### 🟡 MEDIUM / 🟢 LOW — Guava (alerts #64, #65, #66)
Already at `32.1.3-jre` in root `pom.xml` — no change needed.

### 🟡 MEDIUM — commons-io (alert #62)
Already at `2.14.0` in root `pom.xml` — no change needed.

---

## Cannot Be Fixed

| Alert | Reason |
|-------|--------|
| #67 — ZooKeeper info disclosure in persistent watchers | `"fixed": null` — no upstream patch exists from the Apache ZooKeeper project |

---

## Test plan

- [ ] Build: `mvn clean install -DskipTests`
- [ ] graph-core: `mvn test -pl ontology-engine/graph-core_2.13 -DfailIfNoTests=false` — 0 suites aborted, no SnakeYAML errors
- [ ] graph-engine: `mvn test -pl ontology-engine/graph-engine_2.13 -DfailIfNoTests=false` — 0 suites aborted
- [ ] Docker must be running for testcontainers-based tests
- [ ] Dependabot alerts should auto-close after merge (except #67)

🤖 Generated with [Claude Code](https://claude.com/claude-code)