### PR TITLE
fix: env var fallback for cloud storage and graph health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ mvn clean install -DskipTests -Poci   # Oracle Cloud Infrastructure
 
 ### Step 6 — Run a service
 
+> **Required:** Set [cloud storage environment variables](#cloud-storage-configuration) before starting any service. The `StorageModule` initializes eagerly on startup and the service will fail if the variables are empty. If you don't have real credentials, set placeholder values — storage will only fail when you actually upload/download content:
+> ```shell
+> export cloud_storage_type=azure
+> export cloud_storage_key=placeholder
+> export cloud_storage_secret=placeholder
+> export cloud_storage_container=placeholder
+> ```
+
 You can either run services individually or run Content, Taxonomy, and Assessment together via `knowlg-service`.
 
 #### Option A — Run an individual service

--- a/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/health/HealthCheckManager.scala
+++ b/ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/health/HealthCheckManager.scala
@@ -9,7 +9,8 @@ import org.sunbird.common.dto.{Request, Response, ResponseHandler}
 import org.sunbird.graph.OntologyEngineContext
 import org.sunbird.graph.service.operation.NodeAsyncOperations
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
 object HealthCheckManager extends CassandraConnector with RedisConnector {
@@ -34,12 +35,8 @@ object HealthCheckManager extends CassandraConnector with RedisConnector {
 
     private def checkGraphHealth()(implicit oec: OntologyEngineContext, ec: ExecutionContext): Map[String, Any] = {
         try {
-            val futureNode = oec.graphService.upsertRootNode("domain", new Request())
-            if (futureNode.isCompleted) {
-                generateCheck(true, graphDBLabel)
-            } else {
-                generateCheck(false, graphDBLabel)
-            }
+            Await.result(oec.graphService.upsertRootNode("domain", new Request()), 5.seconds)
+            generateCheck(true, graphDBLabel)
         } catch {
             case e: Exception => generateCheck(false, graphDBLabel)
         }

--- a/platform-modules/mimetype-manager/src/main/java/modules/StorageModule.java
+++ b/platform-modules/mimetype-manager/src/main/java/modules/StorageModule.java
@@ -58,10 +58,8 @@ public class StorageModule extends AbstractModule {
     @Provides
     @Singleton
     public IStorageService provideStorageService() {
-        String storageType = config.hasPath("cloud_storage_type")
-                ? config.getString("cloud_storage_type") : "azure";
-        String authTypeStr = config.hasPath("cloud_storage_auth_type")
-                ? config.getString("cloud_storage_auth_type").toUpperCase() : "ACCESS_KEY";
+        String storageType = getConfigOrEnv("cloud_storage_type", "azure");
+        String authTypeStr = getConfigOrEnv("cloud_storage_auth_type", "ACCESS_KEY").toUpperCase();
 
         // StorageType and AuthType are inner classes of StorageConfig in v2.0.0
         StorageConfig.StorageType storageTypeEnum = StorageConfig.StorageType.valueOf(storageType.toUpperCase());
@@ -71,19 +69,34 @@ public class StorageModule extends AbstractModule {
 
         // The 'storageKey' (Azure Account Name) is required even for OIDC
         // to construct the correct service URL (e.g. https://<account_name>.blob.core.windows.net)
-        String storageKey = config.hasPath("cloud_storage_key")
-                ? config.getString("cloud_storage_key") : "";
+        String storageKey = getConfigOrEnv("cloud_storage_key", "");
         builder.storageKey(storageKey);
 
         if (authType == StorageConfig.AuthType.ACCESS_KEY) {
             // Developer / local environment: use static secret from config
-            String storageSecret = config.hasPath("cloud_storage_secret")
-                    ? config.getString("cloud_storage_secret") : "";
+            String storageSecret = getConfigOrEnv("cloud_storage_secret", "");
             builder.storageSecret(storageSecret);
         }
         // For OIDC / IAM: the Azure SDK resolves credentials automatically via Workload Identity
         // or Managed Identity — no static secret needed.
 
         return StorageServiceFactory.getStorageService(builder.build());
+    }
+
+    /**
+     * Reads a value from Play config, falling back to an environment variable of the same name
+     * if the config value is empty. This allows {@code export cloud_storage_key=...} to work
+     * even when the packaged application.conf has an empty default.
+     */
+    private String getConfigOrEnv(String key, String defaultValue) {
+        String value = config.hasPath(key) ? config.getString(key) : "";
+        if (value != null && !value.isEmpty()) {
+            return value;
+        }
+        String envValue = System.getenv(key);
+        if (envValue != null && !envValue.isEmpty()) {
+            return envValue;
+        }
+        return defaultValue;
     }
 }


### PR DESCRIPTION
## Summary

- **StorageModule**: Add `getConfigOrEnv` helper that falls back to `System.getenv()` when the `application.conf` value is empty. This fixes the startup crash (`'name' cannot be empty`) when running the packaged dist (`play2:dist`) with `export cloud_storage_key=...`, since HOCON `${?VAR}` substitution is baked at build time and doesn't resolve env vars at runtime.
- **HealthCheckManager**: Replace `futureNode.isCompleted` (always `false` for async CQL calls) with `Await.result(..., 5.seconds)` so the `/health` endpoint correctly reports graph db status instead of always returning unhealthy.
- **README**: Add required cloud storage env var note with placeholder values before Step 6 (Run a service).

## Files Changed

| File | Change |
|------|--------|
| `platform-modules/mimetype-manager/src/main/java/modules/StorageModule.java` | Add `getConfigOrEnv()` — config → env var → default fallback |
| `ontology-engine/graph-engine_2.13/src/main/scala/org/sunbird/graph/health/HealthCheckManager.scala` | `Await.result` with 5s timeout instead of `isCompleted` |
| `README.md` | Add required env var note in Step 6 |

## Test Plan

- [x] Start knowlg-service with `export cloud_storage_key=placeholder && export cloud_storage_secret=placeholder` — service starts without `'name' cannot be empty` error
- [x] `curl http://localhost:9000/health` — graph db reports `"healthy": true`
- [ ] Verify no regression in K8s deployment (config values set via ConfigMap take precedence over env var fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)