### PR TITLE
ci(deps): add Dependabot scanning and transitive dependency submission

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+version: 2
+updates:
+  # Maven — one entry covers the root pom.xml and all 39 submodule pom.xml files
+  # because Dependabot walks the full module graph from the root.
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"   # 30 min after dependency-submission workflow (03:00 UTC)
+      timezone: "UTC" # so Dependabot reads a freshly submitted transitive graph
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Apache Pekko (actor framework replacing Akka)
+      pekko:
+        patterns:
+          - "org.apache.pekko:*"
+      # Play Framework (web layer for all API services)
+      play-framework:
+        patterns:
+          - "com.typesafe.play:*"
+      # Jackson (JSON serialisation across all modules)
+      jackson:
+        patterns:
+          - "com.fasterxml.jackson*:*"
+      # Kafka client (messaging)
+      kafka:
+        patterns:
+          - "org.apache.kafka:*"
+      # Logging stack
+      logging:
+        patterns:
+          - "ch.qos.logback:*"
+          - "org.slf4j:*"
+      # Apache Commons libraries
+      apache-commons:
+        patterns:
+          - "org.apache.commons:*"
+          - "commons-*:*"
+      # Test-only dependencies
+      testing:
+        patterns:
+          - "org.scalatest:*"
+          - "org.scalamock:*"
+    ignore:
+      # Netty is pinned in the root pom.xml BOM to a version that is
+      # compatible with the Play Framework Netty transport. Bumping it
+      # independently breaks the build. Only update Netty when upgrading
+      # Play Framework.
+      - dependency-name: "io.netty:*"
+
+  # Note: taxonomy-service-sbt/ uses SBT which Dependabot does not support
+  # natively. Dependency alerts for that module come from the GitHub Dependency
+  # Graph submission in dependency-submission.yml (SBOM path).
+
+  # GitHub Actions — keeps CI workflow action versions current
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,10 +53,6 @@ updates:
       # Play Framework.
       - dependency-name: "io.netty:*"
 
-  # Note: taxonomy-service-sbt/ uses SBT which Dependabot does not support
-  # natively. Dependency alerts for that module come from the GitHub Dependency
-  # Graph submission in dependency-submission.yml (SBOM path).
-
   # GitHub Actions — keeps CI workflow action versions current
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,39 @@
+name: Dependency Submission
+
+on:
+  schedule:
+    # 03:00 UTC every Monday — must run before Dependabot scans at 03:30 UTC
+    # so the graph is fresh when Dependabot evaluates vulnerability alerts.
+    - cron: '0 3 * * 1'
+  push:
+    branches: [master]
+    paths:
+      - '**/pom.xml'
+  pull_request:
+    branches: [master]
+    paths:
+      - '**/pom.xml'
+  workflow_dispatch: # allows manual trigger to refresh the graph on demand
+
+# contents: write is required to submit the dependency snapshot to GitHub
+permissions:
+  contents: write
+
+jobs:
+  # Resolves all Maven dependencies (direct + transitive) across all 39 pom.xml
+  # files in the monorepo and submits them to the GitHub Dependency Graph.
+  # Dependabot uses this graph to detect vulnerabilities in transitive deps.
+  submit-maven:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '11'       # matches <release>11</release> in root pom.xml
+          distribution: 'temurin'
+          cache: 'maven'           # reuses the local Maven repository across runs
+
+      - uses: advanced-security/maven-dependency-submission-action@v4
+        # No extra config needed: the action discovers the root pom.xml,
+        # resolves all profiles and submodules, and submits the full graph.


### PR DESCRIPTION
Adds two files to enable automated dependency vulnerability detection and version updates across the full Maven multi-module project:                                               
  
  - .github/dependabot.yml — configures Dependabot to scan Maven dependencies (one root entry covers all 39 submodule pom.xml files) and GitHub Actions workflow versions weekly.     
  Packages are grouped to reduce PR noise (pekko, play-framework, jackson, kafka, logging, apache-commons, testing). io.netty:* is explicitly ignored because Netty is pinned in the
  root BOM to match the Play Framework Netty transport — bumping it independently breaks the build.                                                                                   
  - .github/workflows/dependency-submission.yml — runs at 03:00 UTC every Monday (30 minutes before Dependabot scans at 03:30 UTC) to resolve and submit the complete transitive
  dependency tree to the GitHub Dependency Graph. Without this step, Dependabot can only detect vulnerabilities in direct dependencies listed in pom.xml, not in the full transitive  
  closure. Also triggers on any **/pom.xml change pushed to master.
                                                                                                                                                                                      
  How Has This Been Tested?                              

  - Validated dependabot.yml syntax against GitHub Dependabot schema                                                                                                                  
  - Validated dependency-submission.yml YAML structure
  - Confirmed advanced-security/maven-dependency-submission-action@v4 discovers multi-module projects from a root pom.xml without additional configuration                            
  - Verified Netty ignore pattern (io.netty:*) uses the correct Dependabot Maven groupId:artifactId glob syntax                                                                       
  - After merge: confirm Dependency Graph is populated under Insights → Dependency graph and Dependabot alerts are enabled under Security → Dependabot                                
                                                                                                                                                                                      
  Test Configuration:                                                                                                                                                                 
  - Software versions: Java 11, Maven 3.9+, Scala 2.13                                                                                                                                
  - No application code changed — configuration only                                                                                                                                  
  
  Checklist:                                                                                                                                                                          
                                                         
  - My code follows the style guidelines of this project                                                                                                                              
  - I have performed a self-review of my own code        
  - I have commented my code, particularly in hard-to-understand areas
  - My changes generate no new warnings                                                                                                                                               
  - I have added tests that prove my fix is effective or that my feature works (N/A — CI configuration)
  - New and existing unit tests pass locally with my changes (no application code changed)                                                                                            
  - Any dependent changes have been merged and published in downstream modules