### PR TITLE
fix: Preserve mimeType during HTML sanitization and add unit test

### DIFF
--- a/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
+++ b/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
@@ -40,7 +40,7 @@ public class HtmlSanitizer {
             "createdOn", "lastUpdatedOn", "lastStatusChangedOn", "lastPublishedOn",
             "lastSubmittedOn", "versionDate", "artifactUrl", "downloadUrl", "previewUrl",
             "streamingUrl", "appIcon", "posterImage", "toc_url",
-            "sYS_INTERNAL_LAST_UPDATED_ON", "prevStatus"
+            "sYS_INTERNAL_LAST_UPDATED_ON", "prevStatus", "mimeType"
     ));
 
     private static final Pattern TIMESTAMP_PATTERN = Pattern.compile(

--- a/platform-core/platform-common/src/test/java/org/sunbird/common/HtmlSanitizerTest.java
+++ b/platform-core/platform-common/src/test/java/org/sunbird/common/HtmlSanitizerTest.java
@@ -283,6 +283,15 @@ public class HtmlSanitizerTest {
     }
 
     @Test
+    public void testSanitizeMapPreservesMimeType() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("mimeType", "image/svg+xml");
+        data.put("name", "Test Asset");
+        HtmlSanitizer.sanitizeMap(data);
+        Assert.assertEquals("image/svg+xml", data.get("mimeType"));
+    }
+
+    @Test
     public void testSanitizeMapWithFrameworkXssPayload() {
         Map<String, Object> data = new HashMap<>();
         data.put("name", "<script>alert('xss-framework')</script>");


### PR DESCRIPTION
### Summary:

- Added mimeType to the list of fields excluded from sanitization to ensure  mimetype values such as `image/svg+xml` remain unchanged.
- Introduced a new unit test: testSanitizeMapPreservesMimeType.
- Verified that sanitizeMap correctly preserves the mimeType field without modifying its value.


