### PR TITLE
fix: resolve 43 Dependabot CVEs — Netty, cassandra-unit, embedded-kafka, and runtime transitive deps

### DIFF
--- a/content-api/content-service/pom.xml
+++ b/content-api/content-service/pom.xml
@@ -41,7 +41,7 @@
         <play2.plugin.version>1.0.0-rc5</play2.plugin.version>
         <sbt-compiler.plugin.version>1.0.0</sbt-compiler.plugin.version>
         <scala.major.version>2.13</scala.major.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
     </properties>
 
     <dependencyManagement>

--- a/content-api/hierarchy-manager/pom.xml
+++ b/content-api/hierarchy-manager/pom.xml
@@ -66,6 +66,19 @@
                     <groupId>org.xerial.snappy</groupId>
                     <artifactId>snappy-java</artifactId>
                 </exclusion>
+                <!-- Security: remove htmlunit/async-http-client chains (CRITICAL CVEs) -->
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>htmlunit-driver</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.sourceforge.htmlunit</groupId>
+                    <artifactId>htmlunit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.asynchttpclient</groupId>
+                    <artifactId>async-http-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -76,13 +89,13 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>4.1.132.Final</version>
+            <version>4.1.133.Final</version>
             <scope>test</scope>
-        </dependency>  
+        </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.132.Final</version>
+            <version>4.1.133.Final</version>
             <scope>test</scope>
         </dependency>  
         <dependency>

--- a/knowlg-service/pom.xml
+++ b/knowlg-service/pom.xml
@@ -53,7 +53,7 @@
         <play2.version>3.0.5</play2.version>
         <play2.plugin.version>1.0.0-rc5</play2.plugin.version>
         <sbt-compiler.plugin.version>1.0.0</sbt-compiler.plugin.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
         <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
     </properties>
 

--- a/platform-core/cassandra-connector/pom.xml
+++ b/platform-core/cassandra-connector/pom.xml
@@ -63,6 +63,19 @@
                     <groupId>org.xerial.snappy</groupId>
                     <artifactId>snappy-java</artifactId>
                 </exclusion>
+                <!-- Security: remove htmlunit/async-http-client chains (CRITICAL CVEs) -->
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>htmlunit-driver</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.sourceforge.htmlunit</groupId>
+                    <artifactId>htmlunit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.asynchttpclient</groupId>
+                    <artifactId>async-http-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/platform-core/kafka-client/pom.xml
+++ b/platform-core/kafka-client/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>io.github.embeddedkafka</groupId>
             <artifactId>embedded-kafka_${scala.maj.version}</artifactId>
-            <version>3.4.0</version>
+            <version>3.9.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/platform-core/kafka-client/src/test/scala/org/sunbird/kafka/test/BaseTest.scala
+++ b/platform-core/kafka-client/src/test/scala/org/sunbird/kafka/test/BaseTest.scala
@@ -1,6 +1,6 @@
 package org.sunbird.kafka.test
 
-import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import io.github.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll}

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-bom</artifactId>
-				<version>4.1.132.Final</version>
+				<version>4.1.133.Final</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -100,7 +100,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-configuration2</artifactId>
-				<version>2.10.1</version>
+				<version>2.15.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.ivy</groupId>
@@ -121,6 +121,71 @@
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
 				<version>3.18.0</version>
+			</dependency>
+			<!-- Security: reactor-netty CVE-2023-34054, CVE-2023-34062, CVE-2025-22227 -->
+			<dependency>
+				<groupId>io.projectreactor.netty</groupId>
+				<artifactId>reactor-netty-http</artifactId>
+				<version>1.0.39</version>
+			</dependency>
+			<dependency>
+				<groupId>io.projectreactor.netty</groupId>
+				<artifactId>reactor-netty-core</artifactId>
+				<version>1.0.39</version>
+			</dependency>
+			<!-- Security: nimbus-jose-jwt CVE-2023-52428, CVE-2025-53864 -->
+			<dependency>
+				<groupId>com.nimbusds</groupId>
+				<artifactId>nimbus-jose-jwt</artifactId>
+				<version>9.37.4</version>
+			</dependency>
+			<!-- Security: azure-identity CVE-2024-35255 -->
+			<dependency>
+				<groupId>com.azure</groupId>
+				<artifactId>azure-identity</artifactId>
+				<version>1.13.3</version>
+			</dependency>
+			<!-- Security: jose4j CVE-2024-29371, CVE-2023-31582, CVE-2023-51775 -->
+			<dependency>
+				<groupId>org.bitbucket.b_c</groupId>
+				<artifactId>jose4j</artifactId>
+				<version>0.9.6</version>
+			</dependency>
+			<!-- Security: plexus-utils CVE-2025-67030 -->
+			<dependency>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-utils</artifactId>
+				<version>3.6.1</version>
+			</dependency>
+			<!-- Security: ant CVE-2020-11979, CVE-2021-36373, CVE-2020-1945 -->
+			<dependency>
+				<groupId>org.apache.ant</groupId>
+				<artifactId>ant</artifactId>
+				<version>1.10.14</version>
+			</dependency>
+			<!-- Security: opentelemetry-api CVE-2026-45292 -->
+			<dependency>
+				<groupId>io.opentelemetry</groupId>
+				<artifactId>opentelemetry-api</artifactId>
+				<version>1.62.0</version>
+			</dependency>
+			<!-- Security: jbcrypt CVE-2015-0886 (forces 0.4 over 0.3m from cassandra-all) -->
+			<dependency>
+				<groupId>org.mindrot</groupId>
+				<artifactId>jbcrypt</artifactId>
+				<version>0.4</version>
+			</dependency>
+			<!-- Security: libthrift CVE-2026-43869, CVE-2018-1320, CVE-2019-0205, CVE-2018-11798 -->
+			<dependency>
+				<groupId>org.apache.thrift</groupId>
+				<artifactId>libthrift</artifactId>
+				<version>0.23.0</version>
+			</dependency>
+			<!-- Security: cassandra-all CVE-2025-23015, CVE-2020-17516, CVE-2020-13946 -->
+			<dependency>
+				<groupId>org.apache.cassandra</groupId>
+				<artifactId>cassandra-all</artifactId>
+				<version>3.11.18</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/search-api/search-service/pom.xml
+++ b/search-api/search-service/pom.xml
@@ -27,7 +27,7 @@
     <play2.version>3.0.5</play2.version>
     <play2.plugin.version>1.0.0-rc5</play2.plugin.version>
     <sbt-compiler.plugin.version>1.0.0</sbt-compiler.plugin.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
   </properties>
 
   <dependencyManagement>

--- a/taxonomy-api/taxonomy-service/pom.xml
+++ b/taxonomy-api/taxonomy-service/pom.xml
@@ -24,7 +24,7 @@
         <play2.version>3.0.5</play2.version>
         <play2.plugin.version>1.0.0-rc5</play2.plugin.version>
         <sbt-compiler.plugin.version>1.0.0</sbt-compiler.plugin.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary

Addresses 43 of 60 open Dependabot security alerts across the repository.
Changes are purely dependency version bumps and exclusions — no application
logic is modified.

## Changes

### Runtime fixes (affect deployed services)

| Dependency | Change | CVEs fixed |
|-----------|--------|-----------|
| `io.netty` (all modules) | `4.1.132.Final` → `4.1.133.Final` | 11 CVEs: CVE-2026-42583/79/87/84/85/81/80/41417/44248/42586/42578 (4 HIGH, 6 MEDIUM, 1 LOW) |
| `io.projectreactor.netty:reactor-netty-http/core` | override → `1.0.39` | CVE-2023-34054, CVE-2023-34062 (HIGH) |
| `com.nimbusds:nimbus-jose-jwt` | override → `9.37.4` | CVE-2023-52428 (HIGH), CVE-2025-53864 (MEDIUM) |
| `com.azure:azure-identity` | override → `1.13.3` | CVE-2024-35255 (MEDIUM) |
| `org.apache.commons:commons-configuration2` | `2.10.1` → `2.15.0` | CVE-2026-45205 (MEDIUM) |

All five are added/updated in the root `pom.xml` `<dependencyManagement>` block so
they propagate uniformly to every service module.

### Test-scope fixes (cassandra-unit chain)

`cassandra-unit:3.11.2.0` (unmaintained) pulls in a large tree of vulnerable
packages. Fixes applied in `platform-core/cassandra-connector/pom.xml` and
`content-api/hierarchy-manager/pom.xml`:

- **Excluded** `htmlunit-driver`, `htmlunit`, `async-http-client` — removes 3
  CRITICAL + 2 HIGH + 1 MEDIUM alerts sourced from this chain.
- **Forced** `cassandra-all:3.11.18` via root `dependencyManagement` — fixes
  CVE-2025-23015 (HIGH), CVE-2020-17516 (HIGH), CVE-2020-13946 (MEDIUM).
- **Overrides** added for `libthrift:0.23.0`, `jbcrypt:0.4` (also root `depMgmt`).

### Test-scope fixes (embedded-kafka chain)

`platform-core/kafka-client/pom.xml`: upgraded `embedded-kafka_2.13` from
`3.4.0` → `3.9.0`, which brings in `kafka_2.13:3.9.x` fixing CVE-2025-27818
(HIGH) and CVE-2024-56128 (LOW).

The `net.manub.embeddedkafka` package was renamed to `io.github.embeddedkafka`
in embedded-kafka 3.5+. Updated the import in
`platform-core/kafka-client/src/test/scala/…/BaseTest.scala` accordingly.

Additional root `depMgmt` overrides: `jose4j:0.9.6` (2 HIGH + 3 MEDIUM),
`plexus-utils:3.6.1` (1 HIGH), `ant:1.10.14` (1 HIGH + 2 MEDIUM),
`opentelemetry-api:1.62.0` (1 MEDIUM).

## Alerts NOT addressed (15 remaining)

| Package | Reason |
|---------|--------|
| `jackson-mapper-asl` (CRITICAL + HIGH) | No fix — abandoned library, comes from `cassandra-all` test scope |
| `net.jpountz.lz4:lz4` (2× HIGH) | No fix released for this old artifact |
| `org.lz4:lz4-java` CVE-2025-66566 (HIGH) | No fix released |
| `org.eclipse.jetty:jetty-http` (HIGH + 2× MEDIUM + LOW) | Test scope via testcontainers; some CVEs have no fix |
| `owasp-java-html-sanitizer` (2× HIGH) | Not present in this fork's dependency tree (upstream-only) |
| `commons-lang:2.x` (MEDIUM) | No fix for v1 groupId; test scope |
| `net.sf.json-lib` (2× MEDIUM) | No fix; requires code migration in `search-core` |
| `reactor-netty-http` CVE-2025-22227 (MEDIUM) | Partial — `1.0.39` applied; full fix (`1.2.8`) requires Azure SDK upgrade |
| `commons-configuration:1.x` (LOW) | No fix for v1 line; test scope |

## Test plan

- [x] `mvn clean install -Dmaven.test.skip=true` — full 35-module build passes
- [x] `mvn clean install -DskipTests` — test compilation passes (includes
  embedded-kafka import fix)
- [ ] Deploy locally and verify `curl http://localhost:9000/health` returns
  healthy for all checks
