### PR TITLE
fix: resolve scoList schema validation and HTML encoding issues

### DIFF
--- a/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
+++ b/platform-core/platform-common/src/main/java/org/sunbird/common/HtmlSanitizer.java
@@ -120,6 +120,7 @@ public class HtmlSanitizer {
         if (data == null || data.isEmpty() || depth > MAX_DEPTH) return;
         List<String> keys = data.keySet().stream().collect(Collectors.toList());
         for (String key : keys) {
+            if (IGNORE_FIELDS.contains(key)) continue;
             Object value = data.get(key);
             if (value instanceof String) {
                 data.put(key, sanitizeField(key, (String) value, depth + 1));
@@ -135,6 +136,7 @@ public class HtmlSanitizer {
 
     private static void sanitizeList(String parentKey, List<Object> list, int depth) {
         if (list == null || list.isEmpty() || depth > MAX_DEPTH) return;
+        if (IGNORE_FIELDS.contains(parentKey)) return;
         for (int i = 0; i < list.size(); i++) {
             Object item = list.get(i);
             if (item instanceof String) {

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
@@ -13,7 +13,7 @@ import org.sunbird.graph.dac.model.Node
 import org.sunbird.mimetype.mgr.{BaseMimeTypeManager, MimeTypeManager}
 import org.sunbird.models.UploadParams
 import org.sunbird.telemetry.logger.TelemetryManager
-
+import java.util
 import scala.concurrent.{ExecutionContext, Future, blocking}
 import scala.xml.{Elem, NodeSeq}
 import scala.xml.factory.XMLLoader
@@ -44,8 +44,13 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
                         
                         val launchFile = scoList.head.getOrElse("href", "")
         
-                        val scoListJson = ScormMimeTypeMgrImpl.mapper.writeValueAsString(scoList)
-                        // removed manual node.getMetadata.put calls
+                        val javaScoList = new util.ArrayList[util.Map[String, String]]()
+
+                        scoList.foreach { sco =>
+                                            val javaMap = new util.HashMap[String, String]()
+                                            sco.foreach { case (k, v) => javaMap.put(k, v) }
+                                            javaScoList.add(javaMap)
+                                        }
 
                         val urls: Array[String] = uploadArtifactToCloud(uploadFile, objectId, filePath)
                         
@@ -58,7 +63,7 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
                                 "s3Key"       -> urls(IDX_S3_KEY),
                                 "size"        -> getFileSize(uploadFile).asInstanceOf[AnyRef],
                                 "launchFile"  -> launchFile,
-                                "scoList"     -> scoListJson
+                                "scoList"     -> javaScoList 
                             )
                         )
 

--- a/schemas/content/1.0/schema.json
+++ b/schemas/content/1.0/schema.json
@@ -20,6 +20,21 @@
       "type": "string",
       "minLength": 5
     },
+    "launchFile": {
+      "type": "string"
+    },
+    "scoList": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "identifier": { "type": "string" },
+          "title": { "type": "string" },
+          "href": { "type": "string" },
+          "parameters": { "type": "string" }
+        }
+      }
+    },
     "code": {
       "type": "string"
     },


### PR DESCRIPTION
## Summary
Fixes `Validation Errors` and `UnsupportedOperationException` occurring during SCORM content upload when schema validation is enabled.
## Changes
- **ScormMimeTypeMgrImpl.scala:** 
    - Converted `scoList` from a Scala `List[Map]` to a mutable `java.util.ArrayList[util.Map]`. 
    - This ensures the data structure is fully compatible with the schema validator (which expects an Array) and prevents `UnsupportedOperationException` by avoiding the use of immutable Scala collection wrappers during the sanitization process.
- **HtmlSanitizer.java:**
    - Updated `sanitizeMap` and `sanitizeList` to check for fields listed in `IGNORE_FIELDS` during recursive traversal.
    - Previously, the sanitizer only respected `IGNORE_FIELDS` for top-level `String` values. This change ensures it correctly skips sanitization for nested `List`s and `Map`s, preventing the HTML-escaping of special characters (e.g., `=` turning into `&#61;`) in fields like `scoList`.