### PR TITLE
feat: SCORM 2004 manifest parsing with xml:base composition

### DIFF
--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
@@ -1,11 +1,8 @@
 package org.sunbird.mimetype.mgr.impl
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import java.io.File
 import java.nio.file.Paths
 import javax.xml.parsers.SAXParserFactory
-import play.api.libs.json.Json
 import org.sunbird.cloudstore.StorageService
 import org.sunbird.common.exception.ClientException
 import org.sunbird.graph.OntologyEngineContext
@@ -14,123 +11,169 @@ import org.sunbird.mimetype.mgr.{BaseMimeTypeManager, MimeTypeManager}
 import org.sunbird.models.UploadParams
 import org.sunbird.telemetry.logger.TelemetryManager
 import java.util
-import scala.concurrent.{ExecutionContext, Future, blocking}
-import scala.xml.{Elem, NodeSeq}
-import scala.xml.factory.XMLLoader
-
-object ScormMimeTypeMgrImpl {
-    private val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
-}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.xml.Elem
 
 class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeManager()(ss) with MimeTypeManager {
 
     override def upload(objectId: String, node: Node, uploadFile: File, filePath: Option[String], params: UploadParams)(implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
-                validateUploadRequest(objectId, node, uploadFile)
-                TelemetryManager.info("SCORM content upload for objectId:: " + objectId)
-                val extractionBasePath = getBasePath(objectId)
-                try {
-                    if (isValidPackageStructure(uploadFile, List("imsmanifest.xml"))) {
-                        extractPackage(uploadFile, extractionBasePath)
-                        val manifestFile = new File(extractionBasePath + File.separator + "imsmanifest.xml")
-                        
-                        val scoList = getScoList(getSecureXml(manifestFile))
+        validateUploadRequest(objectId, node, uploadFile)
+        TelemetryManager.info("SCORM content upload for objectId:: " + objectId)
+        val extractionBasePath = getBasePath(objectId)
+        try {
+            if (isValidPackageStructure(uploadFile, List("imsmanifest.xml"))) {
+                extractPackage(uploadFile, extractionBasePath)
+                val manifestFile = new File(extractionBasePath + File.separator + "imsmanifest.xml")
+                val manifestXml  = getSecureXml(manifestFile)
+                val scormVersion = detectScormVersion(manifestXml)
+                val scoList      = getScoList(manifestXml, scormVersion)
 
-                        if (scoList.isEmpty) {
-                            throw new ClientException("ERR_INVALID_FILE", "No SCOs found in imsmanifest.xml!")
-                        }
+                if (scoList.isEmpty)
+                    throw new ClientException("ERR_INVALID_FILE", "No SCOs found in imsmanifest.xml!")
 
-                        // Validate all SCO hrefs up-front
-                        scoList.foreach(sco => getValidatedLaunchFile(extractionBasePath, sco.getOrElse("href", "")))
-                        
-                        val launchFile = scoList.head.getOrElse("href", "")
-        
-                        val javaScoList = new util.ArrayList[util.Map[String, String]]()
+                // Validate all SCO hrefs up-front
+                scoList.foreach(sco => getValidatedLaunchFile(extractionBasePath, sco.getOrElse("href", "")))
 
-                        scoList.foreach { sco =>
-                                            val javaMap = new util.HashMap[String, String]()
-                                            sco.foreach { case (k, v) => javaMap.put(k, v) }
-                                            javaScoList.add(javaMap)
-                                        }
+                val launchFile = scoList.head.getOrElse("href", "")
 
-                        val urls: Array[String] = uploadArtifactToCloud(uploadFile, objectId, filePath)
-                        
-                        extractPackageInCloud(objectId, uploadFile, node, "snapshot", false)
-                        
-                        Future(
-                            Map[String, AnyRef](
-                                "identifier"  -> objectId,
-                                "artifactUrl" -> urls(IDX_S3_URL),
-                                "s3Key"       -> urls(IDX_S3_KEY),
-                                "size"        -> getFileSize(uploadFile).asInstanceOf[AnyRef],
-                                "launchFile"  -> launchFile,
-                                "scoList"     -> javaScoList 
-                            )
-                        )
-
-                    } else {
-                        TelemetryManager.error("ERR_INVALID_FILE:: " + "Invalid SCORM package structure: imsmanifest.xml not found! with file name: " + uploadFile.getName)
-                        throw new ClientException("ERR_INVALID_FILE", "Invalid SCORM package: imsmanifest.xml is missing!")
-                    }
-                } finally {
-                    delete(new File(extractionBasePath))
+                val javaScoList = new util.ArrayList[util.Map[String, String]]()
+                scoList.foreach { sco =>
+                    val javaMap = new util.HashMap[String, String]()
+                    sco.foreach { case (k, v) => javaMap.put(k, v) }
+                    javaScoList.add(javaMap)
                 }
 
+                val urls: Array[String] = uploadArtifactToCloud(uploadFile, objectId, filePath)
+                extractPackageInCloud(objectId, uploadFile, node, "snapshot", false)
+
+                Future(
+                    Map[String, AnyRef](
+                        "identifier"   -> objectId,
+                        "artifactUrl"  -> urls(IDX_S3_URL),
+                        "s3Key"        -> urls(IDX_S3_KEY),
+                        "size"         -> getFileSize(uploadFile).asInstanceOf[AnyRef],
+                        "launchFile"   -> launchFile,
+                        "scoList"      -> javaScoList,
+                        "scormVersion" -> scormVersion
+                    )
+                )
+
+            } else {
+                TelemetryManager.error("ERR_INVALID_FILE:: Invalid SCORM package: imsmanifest.xml not found for objectId: " + objectId)
+                throw new ClientException("ERR_INVALID_FILE", "Invalid SCORM package: imsmanifest.xml is missing!")
+            }
+        } finally {
+            delete(new File(extractionBasePath))
+        }
     }
 
-private def getValidatedLaunchFile(extractionBasePath: String, launchFile: String): String = {
-    if (launchFile.isEmpty) {
-        throw new ClientException("ERR_INVALID_FILE", "Invalid launch file path!")
+    override def upload(objectId: String, node: Node, fileUrl: String, filePath: Option[String], params: UploadParams)
+                       (implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
+        validateUploadRequest(objectId, node, fileUrl)
+        val file = copyURLToFile(objectId, fileUrl)
+        upload(objectId, node, file, filePath, params)
     }
 
-    val delimiterIndex = launchFile.indexWhere(c => c == '?' || c == '#')
-    val cleanLaunchFile = if (delimiterIndex != -1) launchFile.substring(0, delimiterIndex) else launchFile
-
-    val basePath = Paths.get(extractionBasePath)
-    val launchPath = basePath.resolve(cleanLaunchFile).normalize()
-    
-    TelemetryManager.info(s"Validating launch file: basePath=$basePath, launchFile=$cleanLaunchFile, combinedPath=${launchPath.toAbsolutePath}")
-
-    if (!launchPath.startsWith(basePath)) {
-        TelemetryManager.error("ERR_INVALID_FILE:: Potential path traversal detected: " + cleanLaunchFile)
-        throw new ClientException("ERR_INVALID_FILE", "Invalid launch file path!")
+    override def review(objectId: String, node: Node)
+                       (implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
+        validate(node, "[SCORM file should be uploaded for further processing!]")
+        Future(getEnrichedMetadata(node.getMetadata.getOrDefault("status", "").asInstanceOf[String]))
     }
 
-    if (!launchPath.toFile.exists() || launchPath.toFile.isDirectory) {
-        TelemetryManager.error("ERR_INVALID_FILE:: Launch file defined in imsmanifest.xml does not exist or is a directory: " + cleanLaunchFile)
-        throw new ClientException("ERR_INVALID_FILE", "The launch file '" + cleanLaunchFile + "' specified in imsmanifest.xml is missing or invalid!")
+    override def publish(objectId: String, node: Node)
+                        (implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
+        validate(node, "[SCORM file should be uploaded for further processing!]")
+        Future(getEnrichedPublishMetadata(node.getMetadata.getOrDefault("status", "").asInstanceOf[String]))
     }
 
-    launchFile
-}
+    private def detectScormVersion(xml: Elem): String = {
 
- private def getScoList(xml: Elem): List[Map[String, String]] = {
-    (xml \\ "item").filter(item => (item \@ "identifierref").nonEmpty).map { item =>
-        val ref = item \@ "identifierref"
-        val title = (item \ "title").text
-        val baseHref = (xml \\ "resource")
-          .find(res => (res \@ "identifier") == ref)
-          .map(_ \@ "href")
-          .getOrElse("")
-        
-        val parameters = (item \@ "parameters")
-                        .replace("&#61;", "=") 
-                        .replace("&#64;", "@")  
-                        .replace("&#63;", "?")   
-                        .replace("&amp;", "&")
-                        .replace("&lt;", "<")
-                        .replace("&gt;", ">")
-                        .replace("&quot;", "\"")
-                        .replace("&apos;", "'")
-        val finalHref = if (parameters.nonEmpty) baseHref + parameters else baseHref
+        val manifestMeta  = xml \ "metadata"
+        val schema        = (manifestMeta \ "schema").text.trim.toLowerCase
+        val schemaVersion = (manifestMeta \ "schemaversion").text.trim.toLowerCase
 
-        Map(
-            "identifier" -> (item \@ "identifier"), 
-            "title"      -> title, 
-            "href"       -> finalHref,
-            "parameters" -> parameters 
-        )
-    }.toList
-}
+
+        if (schema.isEmpty && schemaVersion.isEmpty) return "1.2"
+
+        schemaVersion match {
+            case "1.2"                   => "1.2"
+            case v if v.startsWith("2004") => "2004"
+            case "cam 1.3"               => "2004" 
+            case _ if schema.contains("adl scorm") => "2004"
+            case _ =>
+                TelemetryManager.error(s"Unsupported SCORM version: schema='$schema' schemaversion='$schemaVersion'")
+                throw new ClientException("ERR_INVALID_FILE",
+                    "Unsupported SCORM version. Only SCORM 1.2 and SCORM 2004 are supported.")
+        }
+    }
+
+    private def getScoList(xml: Elem, scormVersion: String): List[Map[String, String]] = {
+
+        val xmlBaseNs     = "{http://www.w3.org/XML/1998/namespace}base"
+        val manifestBase  = xml \@ xmlBaseNs
+        val resourcesElem = (xml \ "resources").headOption.getOrElse(<resources/>)
+        val resourcesBase = resourcesElem \@ xmlBaseNs
+
+        (xml \\ "item").filter(item => (item \@ "identifierref").nonEmpty).flatMap { item =>
+            val ref   = item \@ "identifierref"
+            val title = (item \ "title").text
+
+            val resourceNode = (xml \\ "resource").find { res =>
+                (res \@ "identifier") == ref && {
+                    val st = Seq(
+                        res \@ "{http://www.adlnet.org/xsd/adlcp_v1p3}scormType",       
+                        res \@ "{http://www.adlnet.org/xsd/adlcp_rootv1p2}scormType",   
+                        res \@ "scormType"                                               
+                    ).find(_.nonEmpty).getOrElse("").trim.toLowerCase
+
+                    st == "sco" || st.isEmpty
+                }
+            }
+
+            resourceNode.map { res =>
+                val resourceBase = res \@ xmlBaseNs
+                val rawHref      = res \@ "href"
+
+                val baseHref = manifestBase + resourcesBase + resourceBase + rawHref
+                val parameters = item \@ "parameters"
+                val finalHref  = if (parameters.nonEmpty) baseHref + parameters else baseHref
+
+                Map(
+                    "identifier"          -> (item \@ "identifier"),
+                    "title"               -> title,
+                    "href"                -> finalHref,
+                    "parameters"          -> parameters
+                )
+            }
+        }.toList
+    }
+
+    private def getValidatedLaunchFile(extractionBasePath: String, launchFile: String): String = {
+        if (launchFile.isEmpty)
+            throw new ClientException("ERR_INVALID_FILE", "Invalid launch file path!")
+
+        val delimiterIndex = launchFile.indexWhere(c => c == '?' || c == '#')
+        val cleanLaunchFile = if (delimiterIndex != -1) launchFile.substring(0, delimiterIndex) else launchFile
+
+        val basePath   = Paths.get(extractionBasePath)
+        val launchPath = basePath.resolve(cleanLaunchFile).normalize()
+
+        TelemetryManager.info(s"Validating launch file: basePath=$basePath, launchFile=$cleanLaunchFile, resolvedPath=${launchPath.toAbsolutePath}")
+
+        if (!launchPath.startsWith(basePath)) {
+            TelemetryManager.error("ERR_INVALID_FILE:: Potential path traversal detected: " + cleanLaunchFile)
+            throw new ClientException("ERR_INVALID_FILE", "Invalid launch file path!")
+        }
+
+        if (!launchPath.toFile.exists() || launchPath.toFile.isDirectory) {
+            TelemetryManager.error("ERR_INVALID_FILE:: Launch file missing or is a directory: " + cleanLaunchFile)
+            throw new ClientException("ERR_INVALID_FILE",
+                s"The launch file '$cleanLaunchFile' specified in imsmanifest.xml is missing or invalid!")
+        }
+
+        launchFile
+    }
+
     private def getSecureXml(manifestFile: File): Elem = {
         val spf = SAXParserFactory.newInstance()
         spf.setNamespaceAware(true)
@@ -138,26 +181,9 @@ private def getValidatedLaunchFile(extractionBasePath: String, launchFile: Strin
         spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
         spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
         spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-        
+
         val saxParser = spf.newSAXParser()
         scala.xml.XML.withSAXParser(saxParser).loadFile(manifestFile)
     }
 
-    
-
-    override def upload(objectId: String, node: Node, fileUrl: String, filePath: Option[String], params: UploadParams)(implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
-        validateUploadRequest(objectId, node, fileUrl)
-        val file = copyURLToFile(objectId, fileUrl)
-        upload(objectId, node, file, filePath, params)
-    }
-
-    override def review(objectId: String, node: Node)(implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
-        validate(node, "[SCORM file should be uploaded for further processing!]")
-        Future(getEnrichedMetadata(node.getMetadata.getOrDefault("status", "").asInstanceOf[String]))
-    }
-
-    override def publish(objectId: String, node: Node)(implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
-        validate(node, "[SCORM file should be uploaded for further processing!]")
-        Future(getEnrichedPublishMetadata(node.getMetadata.getOrDefault("status", "").asInstanceOf[String]))
-    }
 }

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
@@ -17,9 +17,9 @@ import scala.xml.Elem
 class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeManager()(ss) with MimeTypeManager {
 
     override def upload(objectId: String, node: Node, uploadFile: File, filePath: Option[String], params: UploadParams)(implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
-        validateUploadRequest(objectId, node, uploadFile)
-        TelemetryManager.info("SCORM content upload for objectId:: " + objectId)
-        val extractionBasePath = getBasePath(objectId)
+            validateUploadRequest(objectId, node, uploadFile)
+            TelemetryManager.info("SCORM content upload for objectId:: " + objectId)
+            val extractionBasePath = getBasePath(objectId)
         try {
             if (isValidPackageStructure(uploadFile, List("imsmanifest.xml"))) {
                 extractPackage(uploadFile, extractionBasePath)
@@ -98,7 +98,7 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
         schemaVersion match {
             case "1.2"                   => "1.2"
             case v if v.startsWith("2004") => "2004"
-            case "cam 1.3"               => "2004" 
+            case "1.3" if schema == "cam" => "2004" 
             case _ if schema.contains("adl scorm") => "2004"
             case _ =>
                 TelemetryManager.error(s"Unsupported SCORM version: schema='$schema' schemaversion='$schemaVersion'")
@@ -126,7 +126,7 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
                         res \@ "scormType"                                               
                     ).find(_.nonEmpty).getOrElse("").trim.toLowerCase
 
-                    st == "sco" || st.isEmpty
+                    st == "sco" || (st.isEmpty && scormVersion == "1.2")
                 }
             }
 

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
@@ -17,71 +17,68 @@ import scala.xml.Elem
 class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeManager()(ss) with MimeTypeManager {
 
     override def upload(objectId: String, node: Node, uploadFile: File, filePath: Option[String], params: UploadParams)(implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
-            validateUploadRequest(objectId, node, uploadFile)
-            TelemetryManager.info("SCORM content upload for objectId:: " + objectId)
-            val extractionBasePath = getBasePath(objectId)
-        try {
-            if (isValidPackageStructure(uploadFile, List("imsmanifest.xml"))) {
-                extractPackage(uploadFile, extractionBasePath)
-                val manifestFile = new File(extractionBasePath + File.separator + "imsmanifest.xml")
-                val manifestXml  = getSecureXml(manifestFile)
-                val scormVersion = detectScormVersion(manifestXml)
-                val scoList      = getScoList(manifestXml, scormVersion)
+                validateUploadRequest(objectId, node, uploadFile)
+                TelemetryManager.info("SCORM content upload for objectId:: " + objectId)
+                val extractionBasePath = getBasePath(objectId)
+                try {
+                    if (isValidPackageStructure(uploadFile, List("imsmanifest.xml"))) {
+                        extractPackage(uploadFile, extractionBasePath)
+                        val manifestFile = new File(extractionBasePath + File.separator + "imsmanifest.xml")
+                        val manifestXml  = getSecureXml(manifestFile)
+                        val scormVersion = detectScormVersion(manifestXml)
+                        val scoList      = getScoList(manifestXml, scormVersion)
 
-                if (scoList.isEmpty)
-                    throw new ClientException("ERR_INVALID_FILE", "No SCOs found in imsmanifest.xml!")
+                        if (scoList.isEmpty)
+                            throw new ClientException("ERR_INVALID_FILE", "No SCOs found in imsmanifest.xml!")
 
-                // Validate all SCO hrefs up-front
-                scoList.foreach(sco => getValidatedLaunchFile(extractionBasePath, sco.getOrElse("href", "")))
+                        // Validate all SCO hrefs up-front
+                        scoList.foreach(sco => getValidatedLaunchFile(extractionBasePath, sco.getOrElse("href", "")))
 
-                val launchFile = scoList.head.getOrElse("href", "")
+                        val launchFile = scoList.head.getOrElse("href", "")
 
-                val javaScoList = new util.ArrayList[util.Map[String, String]]()
-                scoList.foreach { sco =>
-                    val javaMap = new util.HashMap[String, String]()
-                    sco.foreach { case (k, v) => javaMap.put(k, v) }
-                    javaScoList.add(javaMap)
+                        val javaScoList = new util.ArrayList[util.Map[String, String]]()
+                        scoList.foreach { sco =>
+                                            val javaMap = new util.HashMap[String, String]()
+                                            sco.foreach { case (k, v) => javaMap.put(k, v) }
+                                            javaScoList.add(javaMap)
+                                        }
+
+                        val urls: Array[String] = uploadArtifactToCloud(uploadFile, objectId, filePath)
+                        extractPackageInCloud(objectId, uploadFile, node, "snapshot", false)
+
+                        Future(
+                            Map[String, AnyRef](
+                                "identifier"   -> objectId,
+                                "artifactUrl"  -> urls(IDX_S3_URL),
+                                "s3Key"        -> urls(IDX_S3_KEY),
+                                "size"         -> getFileSize(uploadFile).asInstanceOf[AnyRef],
+                                "launchFile"   -> launchFile,
+                                "scoList"      -> javaScoList,
+                                "scormVersion" -> scormVersion
+                            )
+                        )
+
+                    } else {
+                        TelemetryManager.error("ERR_INVALID_FILE:: Invalid SCORM package: imsmanifest.xml not found for objectId: " + objectId)
+                        throw new ClientException("ERR_INVALID_FILE", "Invalid SCORM package: imsmanifest.xml is missing!")
+                    }
+                } finally {
+                    delete(new File(extractionBasePath))
                 }
-
-                val urls: Array[String] = uploadArtifactToCloud(uploadFile, objectId, filePath)
-                extractPackageInCloud(objectId, uploadFile, node, "snapshot", false)
-
-                Future(
-                    Map[String, AnyRef](
-                        "identifier"   -> objectId,
-                        "artifactUrl"  -> urls(IDX_S3_URL),
-                        "s3Key"        -> urls(IDX_S3_KEY),
-                        "size"         -> getFileSize(uploadFile).asInstanceOf[AnyRef],
-                        "launchFile"   -> launchFile,
-                        "scoList"      -> javaScoList,
-                        "scormVersion" -> scormVersion
-                    )
-                )
-
-            } else {
-                TelemetryManager.error("ERR_INVALID_FILE:: Invalid SCORM package: imsmanifest.xml not found for objectId: " + objectId)
-                throw new ClientException("ERR_INVALID_FILE", "Invalid SCORM package: imsmanifest.xml is missing!")
-            }
-        } finally {
-            delete(new File(extractionBasePath))
-        }
     }
 
-    override def upload(objectId: String, node: Node, fileUrl: String, filePath: Option[String], params: UploadParams)
-                       (implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
+    override def upload(objectId: String, node: Node, fileUrl: String, filePath: Option[String], params: UploadParams)(implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
         validateUploadRequest(objectId, node, fileUrl)
         val file = copyURLToFile(objectId, fileUrl)
         upload(objectId, node, file, filePath, params)
     }
 
-    override def review(objectId: String, node: Node)
-                       (implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
+    override def review(objectId: String, node: Node)(implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
         validate(node, "[SCORM file should be uploaded for further processing!]")
         Future(getEnrichedMetadata(node.getMetadata.getOrDefault("status", "").asInstanceOf[String]))
     }
 
-    override def publish(objectId: String, node: Node)
-                        (implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
+    override def publish(objectId: String, node: Node)(implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
         validate(node, "[SCORM file should be uploaded for further processing!]")
         Future(getEnrichedPublishMetadata(node.getMetadata.getOrDefault("status", "").asInstanceOf[String]))
     }

--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
@@ -33,10 +33,11 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
 
                         // Validate all SCO hrefs up-front
                         scoList.foreach(sco => getValidatedLaunchFile(extractionBasePath, sco.getOrElse("href", "")))
-
+                        
                         val launchFile = scoList.head.getOrElse("href", "")
-
+        
                         val javaScoList = new util.ArrayList[util.Map[String, String]]()
+
                         scoList.foreach { sco =>
                                             val javaMap = new util.HashMap[String, String]()
                                             sco.foreach { case (k, v) => javaMap.put(k, v) }
@@ -44,6 +45,7 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
                                         }
 
                         val urls: Array[String] = uploadArtifactToCloud(uploadFile, objectId, filePath)
+                        
                         extractPackageInCloud(objectId, uploadFile, node, "snapshot", false)
 
                         Future(
@@ -67,22 +69,6 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
                 }
     }
 
-    override def upload(objectId: String, node: Node, fileUrl: String, filePath: Option[String], params: UploadParams)(implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
-        validateUploadRequest(objectId, node, fileUrl)
-        val file = copyURLToFile(objectId, fileUrl)
-        upload(objectId, node, file, filePath, params)
-    }
-
-    override def review(objectId: String, node: Node)(implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
-        validate(node, "[SCORM file should be uploaded for further processing!]")
-        Future(getEnrichedMetadata(node.getMetadata.getOrDefault("status", "").asInstanceOf[String]))
-    }
-
-    override def publish(objectId: String, node: Node)(implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
-        validate(node, "[SCORM file should be uploaded for further processing!]")
-        Future(getEnrichedPublishMetadata(node.getMetadata.getOrDefault("status", "").asInstanceOf[String]))
-    }
-
     private def detectScormVersion(xml: Elem): String = {
 
         val manifestMeta  = xml \ "metadata"
@@ -103,6 +89,32 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
                     "Unsupported SCORM version. Only SCORM 1.2 and SCORM 2004 are supported.")
         }
     }
+
+private def getValidatedLaunchFile(extractionBasePath: String, launchFile: String): String = {
+    if (launchFile.isEmpty) {
+        throw new ClientException("ERR_INVALID_FILE", "Invalid launch file path!")
+    }
+
+    val delimiterIndex = launchFile.indexWhere(c => c == '?' || c == '#')
+    val cleanLaunchFile = if (delimiterIndex != -1) launchFile.substring(0, delimiterIndex) else launchFile
+
+    val basePath = Paths.get(extractionBasePath)
+    val launchPath = basePath.resolve(cleanLaunchFile).normalize()
+    
+    TelemetryManager.info(s"Validating launch file: basePath=$basePath, launchFile=$cleanLaunchFile, combinedPath=${launchPath.toAbsolutePath}")
+
+    if (!launchPath.startsWith(basePath)) {
+        TelemetryManager.error("ERR_INVALID_FILE:: Potential path traversal detected: " + cleanLaunchFile)
+        throw new ClientException("ERR_INVALID_FILE", "Invalid launch file path!")
+    }
+
+    if (!launchPath.toFile.exists() || launchPath.toFile.isDirectory) {
+        TelemetryManager.error("ERR_INVALID_FILE:: Launch file defined in imsmanifest.xml does not exist or is a directory: " + cleanLaunchFile)
+        throw new ClientException("ERR_INVALID_FILE", "The launch file '" + cleanLaunchFile + "' specified in imsmanifest.xml is missing or invalid!")
+    }
+
+    launchFile
+}
 
     private def getScoList(xml: Elem, scormVersion: String): List[Map[String, String]] = {
 
@@ -145,32 +157,6 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
         }.toList
     }
 
-    private def getValidatedLaunchFile(extractionBasePath: String, launchFile: String): String = {
-        if (launchFile.isEmpty)
-            throw new ClientException("ERR_INVALID_FILE", "Invalid launch file path!")
-
-        val delimiterIndex = launchFile.indexWhere(c => c == '?' || c == '#')
-        val cleanLaunchFile = if (delimiterIndex != -1) launchFile.substring(0, delimiterIndex) else launchFile
-
-        val basePath   = Paths.get(extractionBasePath)
-        val launchPath = basePath.resolve(cleanLaunchFile).normalize()
-
-        TelemetryManager.info(s"Validating launch file: basePath=$basePath, launchFile=$cleanLaunchFile, resolvedPath=${launchPath.toAbsolutePath}")
-
-        if (!launchPath.startsWith(basePath)) {
-            TelemetryManager.error("ERR_INVALID_FILE:: Potential path traversal detected: " + cleanLaunchFile)
-            throw new ClientException("ERR_INVALID_FILE", "Invalid launch file path!")
-        }
-
-        if (!launchPath.toFile.exists() || launchPath.toFile.isDirectory) {
-            TelemetryManager.error("ERR_INVALID_FILE:: Launch file missing or is a directory: " + cleanLaunchFile)
-            throw new ClientException("ERR_INVALID_FILE",
-                s"The launch file '$cleanLaunchFile' specified in imsmanifest.xml is missing or invalid!")
-        }
-
-        launchFile
-    }
-
     private def getSecureXml(manifestFile: File): Elem = {
         val spf = SAXParserFactory.newInstance()
         spf.setNamespaceAware(true)
@@ -178,9 +164,24 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
         spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
         spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
         spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-
+        
         val saxParser = spf.newSAXParser()
         scala.xml.XML.withSAXParser(saxParser).loadFile(manifestFile)
     }
 
+    override def upload(objectId: String, node: Node, fileUrl: String, filePath: Option[String], params: UploadParams)(implicit ec: ExecutionContext): Future[Map[String, AnyRef]] = {
+        validateUploadRequest(objectId, node, fileUrl)
+        val file = copyURLToFile(objectId, fileUrl)
+        upload(objectId, node, file, filePath, params)
+    }
+
+    override def review(objectId: String, node: Node)(implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
+        validate(node, "[SCORM file should be uploaded for further processing!]")
+        Future(getEnrichedMetadata(node.getMetadata.getOrDefault("status", "").asInstanceOf[String]))
+    }
+
+    override def publish(objectId: String, node: Node)(implicit ec: ExecutionContext, ontologyEngineContext: OntologyEngineContext): Future[Map[String, AnyRef]] = {
+        validate(node, "[SCORM file should be uploaded for further processing!]")
+        Future(getEnrichedPublishMetadata(node.getMetadata.getOrDefault("status", "").asInstanceOf[String]))
+    }
 }

--- a/schemas/content/1.0/schema.json
+++ b/schemas/content/1.0/schema.json
@@ -23,6 +23,9 @@
     "launchFile": {
       "type": "string"
     },
+    "scormVersion": {
+      "type": "string"
+    },
     "scoList": {
       "type": "array",
       "items": {


### PR DESCRIPTION
This PR introduces robust support for SCORM 2004 (2nd, 3rd, and 4th editions) while fixing two key bugs in the existing SCORM 1.2 implementation. 
**Motivation and Context:**
*   **SCORM 1.2 Bug Fixes:** 
    1. The parser previously included "Asset" types in the `scoList`. It now strictly filters by `adlcp:scormType="sco"` (with a backward-compatibility fallback for 1.2 packages missing the attribute).
    2. Removed a brittle, hand-rolled HTML entity decoding chain for parameters, relying instead on Scala's native SAX parser which inherently decodes entities securely.
*   **SCORM 2004 Support:** Added a new `detectScormVersion` parser that intelligently detects 1.2 vs 2004 (including "cam 1.3" quirks). It also adds deep support for `xml:base` path composition across the manifest, resources, and resource levels to accurately construct the final `href` for SCOs.
**Note:** The `scormVersion` property is now explicitly returned in the upload response map for downstream player consumption.
### Type of change
Please choose appropriate options.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules