### PR TITLE
feat: Add audio asset status update on upload, exclude from enrichment

### DIFF
--- a/content-api/content-actors/src/main/scala/org/sunbird/content/upload/mgr/UploadManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/upload/mgr/UploadManager.scala
@@ -24,7 +24,7 @@ import scala.collection.Map
 
 object UploadManager {
 
-	private val MEDIA_TYPE_LIST = List("image", "video")
+	private val MEDIA_TYPE_LIST = List("image", "video", "audio")
 	private val kfClient = new KafkaClient
 	private val CONTENT_ARTIFACT_ONLINE_SIZE: Double = Platform.getDouble("content.artifact.size.for_online", 209715200.asInstanceOf[Double])
 	private val ENABLE_ASSET_ENRICHMENT = Platform.getBoolean("asset_enrichment.enable", true)
@@ -60,7 +60,7 @@ object UploadManager {
 				updateReq.put("contentDisposition", "online-only")
 			
 			if (StringUtils.equalsIgnoreCase("Asset", objectType) && MEDIA_TYPE_LIST.contains(mediaType)) {
-				if (ENABLE_ASSET_ENRICHMENT) {
+				if (ENABLE_ASSET_ENRICHMENT && !StringUtils.equalsIgnoreCase("audio", mediaType)) {
 					updateReq.put("status", "Processing")
 				} else {
 					updateReq.put("status", "Live")
@@ -68,7 +68,7 @@ object UploadManager {
 			}
 
 			DataNode.update(updateReq).map(node => {
-				if (ENABLE_ASSET_ENRICHMENT && StringUtils.equalsIgnoreCase("Asset", objectType) && MEDIA_TYPE_LIST.contains(mediaType) && null != node)
+				if (ENABLE_ASSET_ENRICHMENT && StringUtils.equalsIgnoreCase("Asset", objectType) && MEDIA_TYPE_LIST.contains(mediaType) && !StringUtils.equalsIgnoreCase("audio", mediaType) && null != node)
 					pushInstructionEvent(identifier, node)
 				getUploadResponse(node)
 			})


### PR DESCRIPTION
## Summary
Audio assets now transition to `Live` status after file upload, matching behavior for image/video assets. However, audio is excluded from asset enrichment pipeline.

## Changes
- Added `audio` to `MEDIA_TYPE_LIST` in `UploadManager` to trigger status updates
- Updated enrichment check to skip audio media type, preventing enrichment job submission
- Audio assets always set to `Live` status post-upload, regardless of `asset_enrichment.enable` config

## Why
Audio assets were stuck in `Draft` status after upload while image/video transitioned to `Live`/`Processing`. Audio doesn't require enrichment processing (metadata extraction, format conversion, etc.), so it bypasses that pipeline entirely.

## Testing
- [x] Upload audio asset and verify status is `Live` after upload
- [x] Verify no enrichment job is queued for audio (check Kafka topic)
- [x] Ensure image/video enrichment behavior unchanged
