### PR TITLE
merge: develop into v.1.0.2 with conflict resolution

### DIFF
--- a/.github/build-config.json
+++ b/.github/build-config.json
@@ -5,6 +5,7 @@
     "taxonomy_service": false,
     "assessment_service": false,
     "search_service": true,
-    "knowlg_service": true
+    "knowlg_service": true,
+    "sync_tool": false
   }
 }

--- a/.github/workflows/content-service.yml
+++ b/.github/workflows/content-service.yml
@@ -39,6 +39,11 @@ jobs:
     if: needs.check-config.outputs.should_build == 'true'
     runs-on: ubuntu-latest
 
+    # CSP (cloud service provider) selects the Maven profile and Docker build-arg.
+    # Set the repository/environment variable CSP to azure | aws | gcp | oci. Defaults to azure.
+    env:
+      CSP: ${{ vars.CSP || 'azure' }}
+
     steps:
       # Step 1: Checkout the code
       - name: Checkout code
@@ -67,20 +72,21 @@ jobs:
       # Step 4: Build the project
       - name: Build Content Service
         run: |
-          mvn clean install -DskipTests=true
+          echo "Building with CSP profile: $CSP"
+          mvn clean install -DskipTests=true -P${CSP}
 
       # Step 5: Package the project
       - name: Package Content Service
         run: |
           cd content-api
-          mvn play2:dist -pl content-service
+          mvn play2:dist -pl content-service -P${CSP}
 
       # Step 6: Build Docker image
       - name: Build Docker Image
         run: |
           IMAGE_NAME="content-service"
           IMAGE_TAG=$(echo "${{ github.ref_name }}_$(echo $GITHUB_SHA | cut -c1-7)" | tr '[:upper:]' '[:lower:]')
-          docker build -f build/content-service/Dockerfile -t $REGISTRY_URL/${IMAGE_NAME}:${IMAGE_TAG} .
+          docker build --build-arg CSP=${CSP} -f build/content-service/Dockerfile -t $REGISTRY_URL/${IMAGE_NAME}:${IMAGE_TAG} .
 
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV

--- a/.github/workflows/knowlg-service.yml
+++ b/.github/workflows/knowlg-service.yml
@@ -39,6 +39,11 @@ jobs:
     if: needs.check-config.outputs.should_build == 'true'
     runs-on: ubuntu-latest
 
+    # CSP (cloud service provider) selects the Maven profile and Docker build-arg.
+    # Set the repository/environment variable CSP to azure | aws | gcp | oci. Defaults to azure.
+    env:
+      CSP: ${{ vars.CSP || 'azure' }}
+
     steps:
       # Step 1: Checkout the code
       - name: Checkout code
@@ -67,19 +72,20 @@ jobs:
       # Step 4: Build the project
       - name: Build Knowlg Service
         run: |
-          mvn clean install -DskipTests=true -Paws
+          echo "Building with CSP profile: $CSP"
+          mvn clean install -DskipTests=true -P${CSP}
 
       # Step 5: Package the project
       - name: Package Knowlg Service
         run: |
-          mvn play2:dist -pl knowlg-service -Paws
+          mvn play2:dist -pl knowlg-service -P${CSP}
 
       # Step 6: Build Docker image
       - name: Build Docker Image
         run: |
           IMAGE_NAME="knowlg-service"
           IMAGE_TAG=$(echo "${{ github.ref_name }}_$(echo $GITHUB_SHA | cut -c1-7)" | tr '[:upper:]' '[:lower:]')
-          docker build -f build/knowlg-service/Dockerfile -t $REGISTRY_URL/${IMAGE_NAME}:${IMAGE_TAG} .
+          docker build --build-arg CSP=${CSP} -f build/knowlg-service/Dockerfile -t $REGISTRY_URL/${IMAGE_NAME}:${IMAGE_TAG} .
 
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV

--- a/.github/workflows/knowlg-service.yml
+++ b/.github/workflows/knowlg-service.yml
@@ -67,12 +67,12 @@ jobs:
       # Step 4: Build the project
       - name: Build Knowlg Service
         run: |
-          mvn clean install -DskipTests=true
+          mvn clean install -DskipTests=true -Paws
 
       # Step 5: Package the project
       - name: Package Knowlg Service
         run: |
-          mvn play2:dist -pl knowlg-service
+          mvn play2:dist -pl knowlg-service -Paws
 
       # Step 6: Build Docker image
       - name: Build Docker Image

--- a/.github/workflows/sync-tool.yml
+++ b/.github/workflows/sync-tool.yml
@@ -1,0 +1,79 @@
+name: Build and Push Sync Tool Image
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  check-config:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check if build is enabled
+        id: check
+        env:
+          BUILD_ENABLED_VAR: ${{ vars.SYNC_TOOL_BUILD_ENABLED }}
+        run: |
+          if [ -n "$BUILD_ENABLED_VAR" ]; then
+            ENABLED="$BUILD_ENABLED_VAR"
+            echo "Taking value from SYNC_TOOL_BUILD_ENABLED: $ENABLED"
+          else
+            ENABLED=$(cat .github/build-config.json | jq -r '.services.sync_tool')
+            echo "Taking value from build-config.json: $ENABLED"
+          fi
+          echo "enabled=$ENABLED" >> $GITHUB_OUTPUT
+          echo "Sync Tool build enabled: $ENABLED"
+
+  build-and-push:
+    needs: check-config
+    if: needs.check-config.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11 and Maven
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+
+      - name: Registry Login
+        uses: ./.github/actions/registry-login
+        with:
+          registry_provider: ${{ vars.REGISTRY_PROVIDER }}
+          gcp_service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          registry_name: ${{ secrets.REGISTRY_NAME }}
+          registry_url: ${{ secrets.REGISTRY_URL }}
+          registry_username: ${{ secrets.REGISTRY_USERNAME }}
+          registry_password: ${{ secrets.REGISTRY_PASSWORD }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Sync Tool
+        run: |
+          mvn clean package -pl sync-tool -am -DskipTests=true
+
+      - name: Build Docker Image
+        run: |
+          IMAGE_NAME="sync-tool"
+          IMAGE_TAG=$(echo "${{ github.ref_name }}_$(echo $GITHUB_SHA | cut -c1-7)" | tr '[:upper:]' '[:lower:]')
+          docker build -f sync-tool/Dockerfile -t $REGISTRY_URL/${IMAGE_NAME}:${IMAGE_TAG} sync-tool/
+
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
+      - name: Push Docker Image
+        run: |
+          docker push $REGISTRY_URL/${IMAGE_NAME}:${IMAGE_TAG}
+          echo "Pushed Docker image: $REGISTRY_URL/${IMAGE_NAME}:${IMAGE_TAG}"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.conf
 docker/.migrations
 docker/.es-migrations
+sync-tool/dependency-reduced-pom.xml

--- a/assessment-api/assessment-service/conf/application.conf
+++ b/assessment-api/assessment-service/conf/application.conf
@@ -459,6 +459,9 @@ v5_default_qumlVersion=1.1
 # has no cloud-storage actors currently. Enable it if cloud-using actors are added in
 # the future (also add mimetype-manager dependency to assessment-service pom.xml at that point).
 cloud_storage_type="azure"
+# cloud_storage_region: AWS S3 only — region of the bucket. Ignored by Azure.
+# Leave unset for us-east-1 (SDK default); required for buckets in any other AWS region.
+#cloud_storage_region="ap-south-1"
 # ACCESS_KEY for local dev; OIDC for production K8s (Azure Workload Identity)
 cloud_storage_auth_type="ACCESS_KEY"
 cloud_storage_key=""

--- a/build/knowlg-service/Dockerfile
+++ b/build/knowlg-service/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 # so that exactly one CSP runtime jar is present in lib/; Java ServiceLoader picks it up automatically.
 # cloud_storage_auth_type defaults to OIDC (Kubernetes Workload Identity).
 # Override via K8s ConfigMap or `docker run -e` for local ACCESS_KEY-based development.
-ARG CSP=aws
+ARG CSP=azure
 ENV cloud_storage_type=${CSP}
 ENV cloud_storage_auth_type=OIDC
 

--- a/build/knowlg-service/Dockerfile
+++ b/build/knowlg-service/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 # so that exactly one CSP runtime jar is present in lib/; Java ServiceLoader picks it up automatically.
 # cloud_storage_auth_type defaults to OIDC (Kubernetes Workload Identity).
 # Override via K8s ConfigMap or `docker run -e` for local ACCESS_KEY-based development.
-ARG CSP=azure
+ARG CSP=aws
 ENV cloud_storage_type=${CSP}
 ENV cloud_storage_auth_type=OIDC
 

--- a/content-api/content-service/conf/application.conf
+++ b/content-api/content-service/conf/application.conf
@@ -761,6 +761,9 @@ actor.timeoutMillisec = 30000
 isIndexHtmlValidationRequired=true
 
 cloud_storage_type="azure"
+# cloud_storage_region: AWS S3 only — region of the bucket. Ignored by Azure.
+# Leave unset for us-east-1 (SDK default); required for buckets in any other AWS region.
+#cloud_storage_region="ap-south-1"
 # Auth type: ACCESS_KEY (dev/static credentials) | OIDC (K8s Workload Identity) | IAM (Managed Identity)
 # Override via environment variable or K8s ConfigMap for production deployments.
 cloud_storage_auth_type="ACCESS_KEY"

--- a/content-api/content-service/pom.xml
+++ b/content-api/content-service/pom.xml
@@ -291,18 +291,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- cloud-store-sdk v2.0.1: API module (compile-time only) -->
+        <!-- cloud-store-sdk v2.0.1: API module (compile-time only).
+             CSP runtime jar is supplied by a Maven profile (-Pazure / -Paws / -Pgcp / -Poci).
+             Default profile is 'azure'. See <profiles> section at the bottom of this file. -->
         <dependency>
             <groupId>org.sunbird</groupId>
             <artifactId>cloud-storage-sdk-api</artifactId>
             <version>2.0.1</version>
-        </dependency>
-        <!-- cloud-store-sdk v2.0.1: Azure CSP implementation (runtime - ServiceLoader discovery) -->
-        <dependency>
-            <groupId>org.sunbird</groupId>
-            <artifactId>cloud-storage-sdk-azure</artifactId>
-            <version>2.0.1</version>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
@@ -417,4 +412,65 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- CSP profiles: activated at build time via -P<id>.
+             Each profile bundles exactly one CSP runtime jar so the resulting dist ZIP
+             (and Docker image) contains only the SDK for the chosen cloud provider.
+             Build examples:
+               mvn clean install -DskipTests -Pazure   (default)
+               mvn clean install -DskipTests -Paws
+               mvn clean install -DskipTests -Pgcp
+               mvn clean install -DskipTests -Poci     -->
+        <profile>
+            <id>azure</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-azure</artifactId>
+                    <version>2.0.1</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>aws</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-aws</artifactId>
+                    <version>2.0.1</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>gcp</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-gcp</artifactId>
+                    <version>2.0.1</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>oci</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-oci</artifactId>
+                    <version>2.0.1</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/knowlg-service/conf/application.conf
+++ b/knowlg-service/conf/application.conf
@@ -839,6 +839,9 @@ actor.timeoutMillisec = 30000
 isIndexHtmlValidationRequired=true
 
 cloud_storage_type="azure"
+# cloud_storage_region: AWS S3 only — region of the bucket. Ignored by Azure.
+# Leave unset for us-east-1 (SDK default); required for buckets in any other AWS region.
+#cloud_storage_region="ap-south-1"
 # Auth type: ACCESS_KEY (local dev / static credentials) | OIDC (K8s Workload Identity) | IAM (Managed Identity)
 # Override via environment variable or K8s ConfigMap for production deployments.
 cloud_storage_auth_type="ACCESS_KEY"

--- a/knowlg-service/pom.xml
+++ b/knowlg-service/pom.xml
@@ -222,19 +222,14 @@
             <version>3.2.2</version>
         </dependency>
         
-        <!-- cloud-storage-sdk v2.0.1: explicit dependency (previously only transitive via content-actors) -->
-        <!-- API module — compile-time contract -->
+        <!-- cloud-storage-sdk v2.0.1: explicit dependency (previously only transitive via content-actors).
+             API module — compile-time contract. CSP runtime jar is supplied by a Maven profile
+             (-Pazure / -Paws / -Pgcp / -Poci). Default profile is 'azure'.
+             See <profiles> section at the bottom of this file. -->
         <dependency>
             <groupId>org.sunbird</groupId>
             <artifactId>cloud-storage-sdk-api</artifactId>
             <version>2.0.1</version>
-        </dependency>
-        <!-- Azure CSP implementation — runtime, discovered via Java ServiceLoader -->
-        <dependency>
-            <groupId>org.sunbird</groupId>
-            <artifactId>cloud-storage-sdk-azure</artifactId>
-            <version>2.0.1</version>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- Actor dependencies from JARs -->
@@ -347,5 +342,66 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- CSP profiles: activated at build time via -P<id>.
+             Each profile bundles exactly one CSP runtime jar so the resulting dist ZIP
+             (and Docker image) contains only the SDK for the chosen cloud provider.
+             Build examples:
+               mvn clean install -DskipTests -Pazure   (default)
+               mvn clean install -DskipTests -Paws
+               mvn clean install -DskipTests -Pgcp
+               mvn clean install -DskipTests -Poci     -->
+        <profile>
+            <id>azure</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-azure</artifactId>
+                    <version>2.0.1</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>aws</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-aws</artifactId>
+                    <version>2.0.1</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>gcp</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-gcp</artifactId>
+                    <version>2.0.1</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>oci</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-oci</artifactId>
+                    <version>2.0.1</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/platform-modules/mimetype-manager/src/main/java/modules/StorageModule.java
+++ b/platform-modules/mimetype-manager/src/main/java/modules/StorageModule.java
@@ -67,6 +67,13 @@ public class StorageModule extends AbstractModule {
 
         StorageConfig.Builder builder = StorageConfig.builder(storageTypeEnum).authType(authType);
 
+        // Region: required for non-us-east-1 buckets (e.g. AWS S3). When set, the SDK uses it
+        // explicitly; when empty, the CSP falls back to its default (AWS -> us-east-1).
+        String region = getConfigOrEnv("cloud_storage_region", "");
+        if (!region.isEmpty()) {
+            builder.region(region);
+        }
+
         // The 'storageKey' (Azure Account Name) is required even for OIDC
         // to construct the correct service URL (e.g. https://<account_name>.blob.core.windows.net)
         String storageKey = getConfigOrEnv("cloud_storage_key", "");

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 				<module>taxonomy-api</module>
 				<module>platform-modules</module>
 				<module>search-api</module>
+				<module>sync-tool</module>
 			</modules>
 		</profile>
 		<profile>

--- a/search-api/search-service/conf/application.conf
+++ b/search-api/search-service/conf/application.conf
@@ -378,6 +378,9 @@ semantic_search {
 # has no cloud-storage actors. Enable it if cloud-using actors are added in the future
 # (also add mimetype-manager dependency to search-service pom.xml at that point).
 cloud_storage_type="azure"
+# cloud_storage_region: AWS S3 only — region of the bucket. Ignored by Azure.
+# Leave unset for us-east-1 (SDK default); required for buckets in any other AWS region.
+#cloud_storage_region="ap-south-1"
 # ACCESS_KEY for local dev; OIDC for production K8s (Azure Workload Identity)
 cloud_storage_auth_type="ACCESS_KEY"
 cloud_storage_key=""

--- a/sync-tool/Dockerfile
+++ b/sync-tool/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:11-jre-alpine
+
+WORKDIR /app
+
+COPY target/sync-tool-1.0-SNAPSHOT.jar /app/sync-tool.jar
+
+ENTRYPOINT ["java", "-jar", "/app/sync-tool.jar"]

--- a/sync-tool/Dockerfile
+++ b/sync-tool/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 
 COPY target/sync-tool-1.0-SNAPSHOT.jar /app/sync-tool.jar
 
-ENTRYPOINT ["java", "-jar", "/app/sync-tool.jar"]
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -Dconfig.file=/app/config/application.conf -jar /app/sync-tool.jar \"$@\"", "--"]

--- a/sync-tool/README.md
+++ b/sync-tool/README.md
@@ -1,0 +1,102 @@
+# Sync Tool
+
+Bulk sync tool for populating OpenSearch from JanusGraph. Runs as a K8s Job.
+
+## When to use
+
+- Populating an empty OpenSearch index after environment setup
+- Repairing data after missed/lost CDC events
+- On-demand sync for specific content IDs
+- Backfilling after adding new searchable fields
+
+## Sync Modes
+
+| Mode | Flag | Example |
+|------|------|---------|
+| Specific IDs | `--identifiers` | `--identifiers do_123,do_456` |
+| By objectType | `--objectType` | `--objectType Content` |
+| Recent days | `--days` | `--days 5` |
+| From file | `--file` | `--file /config/node_identifiers.csv` |
+| Full sync | `--type full` | `--type full` |
+
+## Build
+
+```bash
+cd knowledge-platform
+mvn clean package -pl sync-tool -am -DskipTests
+```
+
+## Run locally
+
+```bash
+java -jar sync-tool/target/sync-tool-1.0-SNAPSHOT.jar --objectType Content
+```
+
+Override config via environment variables:
+
+```bash
+export graph_storage_hostname=localhost
+export graph_storage_port=9042
+export search_es_conn_info=localhost:9200
+java -jar sync-tool/target/sync-tool-1.0-SNAPSHOT.jar --objectType Content
+```
+
+## Docker
+
+```bash
+docker build -t sync-tool sync-tool/
+docker run sync-tool --objectType Content
+```
+
+## K8s Job (via install.sh)
+
+```bash
+./install.sh sync_objecttype Content
+./install.sh sync_identifiers do_123,do_456
+./install.sh sync_days 5
+./install.sh sync_file /path/to/node_identifiers.csv
+./install.sh sync_full
+./install.sh sync_deploy    # uses defaults from values.yaml
+```
+
+## Output
+
+```
+[10:00:01] Connecting to JanusGraph...
+[10:00:02] JanusGraph connected.
+[10:00:02] Connecting to OpenSearch...
+[10:00:02] OpenSearch connected.
+[10:00:02] Mode: objectType=Content
+[10:00:03] Enumerated 12,000 nodes
+[10:00:04] Batch 1/60: 200 synced
+[10:00:06] Batch 2/60: 200 synced
+[10:00:07] Batch 3/60: 198 synced, 2 failed [do_312, do_589]
+...
+[10:04:30] Complete. 11,997 synced, 3 failed.
+[10:04:30] Failed IDs: do_312, do_589, do_901
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All nodes synced successfully |
+| 1 | Partial failure — some nodes failed (see output for IDs) |
+| 2 | Fatal error — sync aborted |
+
+## Configuration
+
+Config loaded via Typesafe Config (`application.conf`) with environment variable overrides.
+
+| Config | Default | Description |
+|--------|---------|-------------|
+| `graph.storage.hostname` | localhost | JanusGraph (Cassandra) host |
+| `graph.storage.port` | 9042 | JanusGraph (Cassandra) port |
+| `search.es_conn_info` | localhost:9200 | OpenSearch host:port |
+| `compositesearch.index.name` | compositesearch | OpenSearch index name |
+| `sync.batchSize` | 200 | Nodes per batch |
+| `sync.retryCount` | 3 | Retries per failed batch |
+| `sync.nested.fields` | see application.conf | Fields deserialized to objects |
+| `sync.string.only.fields` | see application.conf | Fields kept as JSON strings |
+| `sync.ignored.fields` | responseDeclaration, body | Fields dropped from index |
+| `sync.restrict.objectTypes` | EventSet, Questionnaire, ... | Object types skipped |

--- a/sync-tool/README.md
+++ b/sync-tool/README.md
@@ -1,6 +1,6 @@
 # Sync Tool
 
-Bulk sync tool for populating OpenSearch from JanusGraph. Runs as a K8s Job.
+Bulk sync tool for populating OpenSearch from JanusGraph.
 
 ## When to use
 
@@ -46,17 +46,6 @@ java -jar sync-tool/target/sync-tool-1.0-SNAPSHOT.jar --objectType Content
 ```bash
 docker build -t sync-tool sync-tool/
 docker run sync-tool --objectType Content
-```
-
-## K8s Job (via install.sh)
-
-```bash
-./install.sh sync_objecttype Content
-./install.sh sync_identifiers do_123,do_456
-./install.sh sync_days 5
-./install.sh sync_file /path/to/node_identifiers.csv
-./install.sh sync_full
-./install.sh sync_deploy    # uses defaults from values.yaml
 ```
 
 ## Output

--- a/sync-tool/pom.xml
+++ b/sync-tool/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>knowledge-platform</artifactId>
+        <groupId>org.sunbird</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sync-tool</artifactId>
+    <packaging>jar</packaging>
+    <name>Sync Tool</name>
+    <description>JanusGraph to OpenSearch bulk sync tool</description>
+
+    <dependencies>
+        <!-- JanusGraph connection (DriverUtil, JanusGraphNodeUtil) -->
+        <dependency>
+            <groupId>org.sunbird</groupId>
+            <artifactId>graph-dac-api</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- OpenSearch client (ElasticSearchUtil) -->
+        <dependency>
+            <groupId>org.sunbird</groupId>
+            <artifactId>search-core</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Jackson for JSON handling -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+
+        <!-- CLI arg parsing -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.5.0</version>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+            <!-- Fat JAR with all dependencies -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.sunbird.sync.SyncTool</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>reference.conf</resource>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sync-tool/src/main/java/org/sunbird/sync/SyncConfig.java
+++ b/sync-tool/src/main/java/org/sunbird/sync/SyncConfig.java
@@ -1,0 +1,47 @@
+package org.sunbird.sync;
+
+import org.sunbird.common.Platform;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SyncConfig {
+
+    public final int batchSize;
+    public final int retryCount;
+    public final List<String> nestedFields;
+    public final List<String> stringOnlyFields;
+    public final List<String> ignoredFields;
+    public final List<String> restrictObjectTypes;
+    public final String graphId;
+    public final String indexName;
+    public final String esConnInfo;
+
+    public SyncConfig() {
+        this.batchSize = Platform.getInteger("sync.batchSize", 200);
+        this.retryCount = Platform.getInteger("sync.retryCount", 3);
+        this.nestedFields = Platform.getStringList("sync.nested.fields", Arrays.asList());
+        this.stringOnlyFields = Platform.getStringList("sync.string.only.fields", Arrays.asList());
+        this.ignoredFields = Platform.getStringList("sync.ignored.fields", Arrays.asList("responseDeclaration", "body"));
+        this.restrictObjectTypes = Platform.getStringList("sync.restrict.objectTypes", Arrays.asList());
+        this.graphId = Platform.getString("graph.graphId", "domain");
+        this.indexName = Platform.getString("compositesearch.index.name", "compositesearch");
+        this.esConnInfo = Platform.getString("search.es_conn_info", "localhost:9200");
+    }
+
+    /** Test-friendly constructor */
+    public SyncConfig(int batchSize, int retryCount, List<String> nestedFields,
+                      List<String> stringOnlyFields, List<String> ignoredFields,
+                      List<String> restrictObjectTypes, String graphId,
+                      String indexName, String esConnInfo) {
+        this.batchSize = batchSize;
+        this.retryCount = retryCount;
+        this.nestedFields = nestedFields;
+        this.stringOnlyFields = stringOnlyFields;
+        this.ignoredFields = ignoredFields;
+        this.restrictObjectTypes = restrictObjectTypes;
+        this.graphId = graphId;
+        this.indexName = indexName;
+        this.esConnInfo = esConnInfo;
+    }
+}

--- a/sync-tool/src/main/java/org/sunbird/sync/SyncTool.java
+++ b/sync-tool/src/main/java/org/sunbird/sync/SyncTool.java
@@ -1,0 +1,271 @@
+package org.sunbird.sync;
+
+import org.apache.commons.cli.*;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.janusgraph.core.JanusGraph;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sunbird.graph.service.util.DriverUtil;
+import org.sunbird.search.client.ElasticSearchUtil;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class SyncTool {
+
+    private static final Logger logger = LoggerFactory.getLogger(SyncTool.class);
+    private static final DateTimeFormatter LOG_FMT = DateTimeFormatter.ofPattern("HH:mm:ss");
+
+    public static void main(String[] args) {
+        Options options = buildOptions();
+        CommandLine cmd;
+        try {
+            cmd = new DefaultParser().parse(options, args);
+        } catch (ParseException e) {
+            System.err.println("Error: " + e.getMessage());
+            new HelpFormatter().printHelp("sync-tool", options);
+            System.exit(1);
+            return;
+        }
+
+        if (cmd.hasOption("help")) {
+            new HelpFormatter().printHelp("sync-tool", options);
+            return;
+        }
+
+        SyncConfig config = new SyncConfig();
+        SyncTransformer transformer = new SyncTransformer(config);
+
+        try {
+            // Initialize connections
+            log("Connecting to JanusGraph...");
+            JanusGraph graph = DriverUtil.getJanusGraph(config.graphId);
+            log("JanusGraph connected.");
+
+            log("Connecting to OpenSearch...");
+            ElasticSearchUtil.initialiseESClient(config.indexName, config.esConnInfo);
+            log("OpenSearch connected.");
+
+            // Enumerate IDs
+            List<String> identifiers = enumerateIds(cmd, graph, config);
+            if (identifiers == null || identifiers.isEmpty()) {
+                log("No nodes to sync.");
+                System.exit(0);
+                return;
+            }
+
+            log("Enumerated " + identifiers.size() + " nodes");
+
+            // Sync in batches
+            int synced = 0;
+            int failed = 0;
+            List<String> failedIds = new ArrayList<>();
+            int totalBatches = (int) Math.ceil((double) identifiers.size() / config.batchSize);
+
+            for (int i = 0; i < identifiers.size(); i += config.batchSize) {
+                int batchNum = (i / config.batchSize) + 1;
+                List<String> batchIds = identifiers.subList(i, Math.min(i + config.batchSize, identifiers.size()));
+
+                BatchResult result = syncBatch(graph, config, transformer, batchIds);
+
+                synced += result.synced;
+                failed += result.failed;
+                failedIds.addAll(result.failedIds);
+
+                if (result.failed > 0) {
+                    log("Batch " + batchNum + "/" + totalBatches + ": " + result.synced + " synced, " +
+                            result.failed + " failed " + result.failedIds);
+                } else {
+                    log("Batch " + batchNum + "/" + totalBatches + ": " + result.synced + " synced");
+                }
+            }
+
+            // Summary
+            log("Complete. " + synced + " synced, " + failed + " failed.");
+            if (!failedIds.isEmpty()) {
+                log("Failed IDs: " + String.join(", ", failedIds));
+            }
+
+            System.exit(failed > 0 ? 1 : 0);
+
+        } catch (Exception e) {
+            logger.error("Sync failed", e);
+            System.exit(2);
+        }
+    }
+
+    private static List<String> enumerateIds(CommandLine cmd, JanusGraph graph, SyncConfig config) throws IOException {
+        GraphTraversalSource g = graph.traversal();
+
+        if (cmd.hasOption("identifiers")) {
+            String[] ids = cmd.getOptionValue("identifiers").split(",");
+            log("Mode: identifiers (" + ids.length + " provided)");
+            return Arrays.asList(ids);
+        }
+
+        if (cmd.hasOption("file")) {
+            String filePath = cmd.getOptionValue("file");
+            log("Mode: file (" + filePath + ")");
+            List<String> ids = Files.readAllLines(Paths.get(filePath)).stream()
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty())
+                    .collect(Collectors.toList());
+            return ids;
+        }
+
+        if (cmd.hasOption("type") && "full".equalsIgnoreCase(cmd.getOptionValue("type"))) {
+            log("Mode: full sync");
+            return g.V().has("IL_UNIQUE_ID")
+                    .values("IL_UNIQUE_ID")
+                    .toList().stream()
+                    .map(Object::toString)
+                    .collect(Collectors.toList());
+        }
+
+        if (cmd.hasOption("objectType")) {
+            String objectType = cmd.getOptionValue("objectType");
+            log("Mode: objectType=" + objectType);
+            return g.V().has("IL_FUNC_OBJECT_TYPE", objectType)
+                    .values("IL_UNIQUE_ID")
+                    .toList().stream()
+                    .map(Object::toString)
+                    .collect(Collectors.toList());
+        }
+
+        if (cmd.hasOption("days")) {
+            int days = Integer.parseInt(cmd.getOptionValue("days"));
+            String cutoff = Instant.now().minus(days, ChronoUnit.DAYS).toString();
+            log("Mode: last " + days + " days (lastUpdatedOn >= " + cutoff + ")");
+            return g.V().has("lastUpdatedOn", org.apache.tinkerpop.gremlin.process.traversal.P.gte(cutoff))
+                    .values("IL_UNIQUE_ID")
+                    .toList().stream()
+                    .map(Object::toString)
+                    .collect(Collectors.toList());
+        }
+
+        System.err.println("Error: No sync mode specified. Use --help for usage.");
+        System.exit(1);
+        return null;
+    }
+
+    private static BatchResult syncBatch(JanusGraph graph, SyncConfig config,
+                                          SyncTransformer transformer, List<String> batchIds) {
+        int retries = 0;
+        while (retries <= config.retryCount) {
+            try {
+                return doSyncBatch(graph, config, transformer, batchIds);
+            } catch (Exception e) {
+                retries++;
+                if (retries <= config.retryCount) {
+                    logger.warn("Batch failed (attempt {}/{}): {}", retries, config.retryCount, e.getMessage());
+                } else {
+                    logger.error("Batch failed after {} retries", config.retryCount, e);
+                    BatchResult result = new BatchResult();
+                    result.failed = batchIds.size();
+                    result.failedIds = new ArrayList<>(batchIds);
+                    return result;
+                }
+            }
+        }
+        // Unreachable
+        return new BatchResult();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static BatchResult doSyncBatch(JanusGraph graph, SyncConfig config,
+                                            SyncTransformer transformer, List<String> batchIds) throws Exception {
+        GraphTraversalSource g = graph.traversal();
+        BatchResult result = new BatchResult();
+
+        // Fetch all properties for batch
+        Map<String, Object> bulkDocs = new HashMap<>();
+
+        for (String identifier : batchIds) {
+            try {
+                List<Map<Object, Object>> vertices = g.V().has("IL_UNIQUE_ID", identifier)
+                        .elementMap().toList();
+
+                if (vertices.isEmpty()) {
+                    logger.warn("Node not found: {}", identifier);
+                    result.failed++;
+                    result.failedIds.add(identifier);
+                    continue;
+                }
+
+                Map<Object, Object> rawProps = vertices.get(0);
+
+                // Convert to String-keyed map
+                Map<String, Object> props = new HashMap<>();
+                for (Map.Entry<Object, Object> entry : rawProps.entrySet()) {
+                    String key = entry.getKey().toString();
+                    // elementMap returns T.id and T.label as keys
+                    if (entry.getKey() == T.id) {
+                        props.put("id", entry.getValue());
+                    } else if (entry.getKey() == T.label) {
+                        // skip vertex label
+                    } else {
+                        props.put(key, entry.getValue());
+                    }
+                }
+
+                Map<String, Object> document = transformer.transform(props);
+                if (document == null) {
+                    // Restricted objectType, skip
+                    continue;
+                }
+
+                bulkDocs.put(identifier, document);
+
+            } catch (Exception e) {
+                logger.warn("Error processing node {}: {}", identifier, e.getMessage());
+                result.failed++;
+                result.failedIds.add(identifier);
+            }
+        }
+
+        // Bulk upsert to OpenSearch
+        if (!bulkDocs.isEmpty()) {
+            ElasticSearchUtil.bulkIndexWithIndexId(config.indexName, bulkDocs);
+            result.synced = bulkDocs.size();
+        }
+
+        return result;
+    }
+
+    private static Options buildOptions() {
+        Options options = new Options();
+        options.addOption(Option.builder().longOpt("identifiers")
+                .hasArg().desc("Comma-separated node IDs to sync").build());
+        options.addOption(Option.builder().longOpt("objectType")
+                .hasArg().desc("Sync all nodes of this objectType").build());
+        options.addOption(Option.builder().longOpt("days")
+                .hasArg().desc("Sync nodes updated in last N days").build());
+        options.addOption(Option.builder().longOpt("file")
+                .hasArg().desc("Path to CSV file with node IDs").build());
+        options.addOption(Option.builder().longOpt("type")
+                .hasArg().desc("Sync type: 'full' for all nodes").build());
+        options.addOption(Option.builder().longOpt("help")
+                .desc("Show usage").build());
+        return options;
+    }
+
+    private static void log(String message) {
+        String timestamp = LocalDateTime.now(ZoneOffset.UTC).format(LOG_FMT);
+        System.out.println("[" + timestamp + "] " + message);
+    }
+
+    static class BatchResult {
+        int synced = 0;
+        int failed = 0;
+        List<String> failedIds = new ArrayList<>();
+    }
+}

--- a/sync-tool/src/main/java/org/sunbird/sync/SyncTransformer.java
+++ b/sync-tool/src/main/java/org/sunbird/sync/SyncTransformer.java
@@ -1,0 +1,171 @@
+package org.sunbird.sync;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Transforms JanusGraph vertex properties into OpenSearch index documents.
+ * Mirrors the behaviour of Flink's CompositeSearchIndexerHelper.buildCompositeIndexerFromGraph()
+ * followed by getIndexDocument() and addMetadataToDocument().
+ *
+ * Transformation rules (same as Flink graph-read path):
+ *  1. stringOnlyFields: if value is List/Map, re-serialize to JSON string.
+ *  2. All other String values starting with { or [: deserialize to Map/List.
+ *  3. Everything else: pass through as-is.
+ *  4. Empty lists become null (removed from document).
+ *  5. External properties (from object definition) are skipped.
+ *  6. Ignored fields are removed.
+ *  7. System fields renamed and added.
+ */
+public class SyncTransformer {
+
+    private static final Logger logger = LoggerFactory.getLogger(SyncTransformer.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final int MAX_FIELD_LENGTH = 32000;
+
+    private final SyncConfig config;
+
+    public SyncTransformer(SyncConfig config) {
+        this.config = config;
+    }
+
+    /**
+     * Transform JanusGraph vertex properties to OpenSearch document.
+     * Returns null if objectType should be skipped.
+     */
+    public Map<String, Object> transform(Map<String, Object> vertexProps) {
+        String objectType = (String) vertexProps.get("IL_FUNC_OBJECT_TYPE");
+        if (objectType != null && config.restrictObjectTypes.contains(objectType)) {
+            return null;
+        }
+
+        Map<String, Object> document = new HashMap<>();
+
+        for (Map.Entry<String, Object> entry : vertexProps.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            // Skip ignored fields
+            if (config.ignoredFields.contains(key)) {
+                continue;
+            }
+
+            // Skip JanusGraph internal fields
+            if (key.startsWith("T.") || key.equals("id")) {
+                continue;
+            }
+
+            // --- Phase 1: buildCompositeIndexerFromGraph behaviour ---
+            // Transform the raw JanusGraph value to the {nv} value
+            value = transformRawValue(key, value);
+
+            // --- Phase 2: getIndexDocument behaviour ---
+            // Empty lists become null → remove from document
+            if (value instanceof List && ((List<?>) value).isEmpty()) {
+                continue;
+            }
+
+            if (value != null) {
+                document.put(key, value);
+            }
+        }
+
+        // Rename system fields
+        renameSystemFields(document);
+
+        // Add system fields
+        addSystemFields(document, vertexProps);
+
+        // Truncate long strings
+        truncateStrings(document);
+
+        return document;
+    }
+
+    /**
+     * Mirrors buildCompositeIndexerFromGraph (lines 268-280 of CompositeSearchIndexerHelper):
+     *
+     *  - stringOnlyFields + value is List/Map → serialize to JSON string
+     *  - non-stringOnlyField + value is String starting with { or [ → deserialize to object
+     *  - everything else → pass through
+     */
+    private Object transformRawValue(String key, Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        // stringOnlyFields: re-serialize List/Map back to JSON string
+        if (config.stringOnlyFields.contains(key)) {
+            if (value instanceof List || value instanceof Map) {
+                try {
+                    return mapper.writeValueAsString(value);
+                } catch (Exception e) {
+                    logger.warn("Failed to serialize stringOnlyField '{}', using toString", key);
+                    return value.toString();
+                }
+            }
+            return value;
+        }
+
+        // All other fields: deserialize any JSON string starting with { or [
+        if (value instanceof String) {
+            String strVal = (String) value;
+            if (strVal.startsWith("{") || strVal.startsWith("[")) {
+                try {
+                    return mapper.readValue(strVal, new TypeReference<Object>() {});
+                } catch (Exception e) {
+                    // Invalid JSON — keep as string (same as Flink catch block)
+                    return value;
+                }
+            }
+        }
+
+        return value;
+    }
+
+    private void renameSystemFields(Map<String, Object> document) {
+        rename(document, "IL_UNIQUE_ID", "identifier");
+        rename(document, "IL_FUNC_OBJECT_TYPE", "objectType");
+        rename(document, "IL_SYS_NODE_TYPE", "nodeType");
+    }
+
+    private void rename(Map<String, Object> document, String oldKey, String newKey) {
+        if (document.containsKey(oldKey)) {
+            document.put(newKey, document.remove(oldKey));
+        }
+    }
+
+    private void addSystemFields(Map<String, Object> document, Map<String, Object> vertexProps) {
+        document.put("graph_id", config.graphId);
+
+        Object vertexId = vertexProps.get("id");
+        if (vertexId != null) {
+            document.put("node_id", vertexId);
+        }
+
+        // Ensure identifier exists
+        if (!document.containsKey("identifier")) {
+            String id = (String) vertexProps.get("IL_UNIQUE_ID");
+            if (id != null) {
+                document.put("identifier", id);
+            }
+        }
+    }
+
+    private void truncateStrings(Map<String, Object> document) {
+        for (Map.Entry<String, Object> entry : document.entrySet()) {
+            if (entry.getValue() instanceof String) {
+                String val = (String) entry.getValue();
+                if (val.length() > MAX_FIELD_LENGTH) {
+                    document.put(entry.getKey(), val.substring(0, MAX_FIELD_LENGTH));
+                }
+            }
+        }
+    }
+}

--- a/sync-tool/src/main/java/org/sunbird/sync/SyncTransformer.java
+++ b/sync-tool/src/main/java/org/sunbird/sync/SyncTransformer.java
@@ -140,8 +140,8 @@ public class SyncTransformer {
         document.put("graph_id", config.graphId);
 
         Object vertexId = vertexProps.get("id");
-        if (vertexId != null) {
-            document.put("node_id", vertexId);
+        if (vertexId instanceof Number) {
+            document.put("node_id", ((Number) vertexId).longValue());
         }
 
         // Ensure identifier exists

--- a/sync-tool/src/main/java/org/sunbird/sync/SyncTransformer.java
+++ b/sync-tool/src/main/java/org/sunbird/sync/SyncTransformer.java
@@ -11,9 +11,6 @@ import java.util.Map;
 
 /**
  * Transforms JanusGraph vertex properties into OpenSearch index documents.
- * Mirrors the behaviour of Flink's CompositeSearchIndexerHelper.buildCompositeIndexerFromGraph()
- * followed by getIndexDocument() and addMetadataToDocument().
- *
  * Transformation rules (same as Flink graph-read path):
  *  1. stringOnlyFields: if value is List/Map, re-serialize to JSON string.
  *  2. All other String values starting with { or [: deserialize to Map/List.
@@ -89,8 +86,6 @@ public class SyncTransformer {
     }
 
     /**
-     * Mirrors buildCompositeIndexerFromGraph (lines 268-280 of CompositeSearchIndexerHelper):
-     *
      *  - stringOnlyFields + value is List/Map → serialize to JSON string
      *  - non-stringOnlyField + value is String starting with { or [ → deserialize to object
      *  - everything else → pass through

--- a/sync-tool/src/main/resources/application.conf
+++ b/sync-tool/src/main/resources/application.conf
@@ -1,0 +1,39 @@
+# Sync Tool Configuration
+
+# Graph
+graph.passport.key.base="31b6fd1c4d64e745c867e61a45edc34a"
+graph.storage.backend="cql"
+graph.storage.hostname="localhost"
+graph.storage.port="9042"
+graph.graphId="domain"
+
+# Route (required by DriverUtil)
+route.all="bolt://localhost:7687"
+route.bolt.write.domain="bolt://localhost:7687"
+
+# OpenSearch
+search.es_conn_info="localhost:9200"
+search.es_scheme="http"
+compositesearch.index.name="compositesearch"
+search.es_username = "admin"
+search.es_password = "SyncT00l@Dev#2026"
+
+# Sync config
+sync {
+    batchSize = 200
+    retryCount = 3
+
+    # Fields stored as nested objects in OpenSearch
+    # Deserialize from JSON string to object before indexing
+    nested.fields = ["badgeAssertions", "targets", "badgeAssociations", "me_totalTimeSpent", "me_totalPlaySessionCount", "me_totalTimeSpentInSec", "me_totalDialcode", "provider", "osMetadata", "actions", "batches", "credentials", "plugins", "trackable"]
+
+    # Fields that must always remain as JSON strings in OpenSearch
+    # If JanusGraph driver pre-parses them, re-serialize back to string
+    string.only.fields = ["interceptionPoints", "editorState", "variants", "timeLimits", "contentTypesCount", "mimeTypesCount", "lhs_options", "rhs_options", "options", "answer", "reservedDialcodes", "issuer", "signatoryList", "data"]
+
+    # Fields to drop from index document (includes external properties from object definitions)
+    ignored.fields = ["responseDeclaration", "body", "oldBody", "stageIcons", "screenshots", "externallink", "hierarchy", "relational_metadata", "instructions", "hints", "media", "interactions", "outcomeDeclaration", "graphId"]
+
+    # Object types to skip during sync
+    restrict.objectTypes = ["EventSet", "Questionnaire", "Misconception", "FrameworkType", "Event"]
+}

--- a/sync-tool/src/main/resources/logback.xml
+++ b/sync-tool/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.sunbird.sync" level="INFO"/>
+    <logger name="DefaultPlatformLogger" level="DEBUG"/>
+    <logger name="org.janusgraph" level="WARN"/>
+    <logger name="org.opensearch" level="WARN"/>
+    <logger name="org.apache.tinkerpop" level="WARN"/>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/sync-tool/src/test/java/org/sunbird/sync/SyncTransformerTest.java
+++ b/sync-tool/src/test/java/org/sunbird/sync/SyncTransformerTest.java
@@ -1,0 +1,397 @@
+package org.sunbird.sync;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class SyncTransformerTest {
+
+    private SyncConfig config;
+    private SyncTransformer transformer;
+
+    @Before
+    public void setUp() {
+        config = new SyncConfig(
+                200, 3,
+                Arrays.asList("badgeAssertions", "targets"),          // nestedFields (not used for deserialization in graph-read path)
+                Arrays.asList("editorState", "options"),               // stringOnlyFields
+                Arrays.asList("responseDeclaration", "body"),          // ignoredFields
+                Arrays.asList("EventSet", "Questionnaire"),            // restrictObjectTypes
+                "domain",
+                "compositesearch",
+                "localhost:9200"
+        );
+        transformer = new SyncTransformer(config);
+    }
+
+    // --- System field renaming ---
+
+    @Test
+    public void testRenamesSystemFields() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("IL_SYS_NODE_TYPE", "DATA_NODE");
+        props.put("name", "Test Content");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertEquals("do_123", doc.get("identifier"));
+        assertEquals("Content", doc.get("objectType"));
+        assertEquals("DATA_NODE", doc.get("nodeType"));
+        assertNull(doc.get("IL_UNIQUE_ID"));
+        assertNull(doc.get("IL_FUNC_OBJECT_TYPE"));
+        assertNull(doc.get("IL_SYS_NODE_TYPE"));
+    }
+
+    // --- System fields added ---
+
+    @Test
+    public void testAddsGraphId() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertEquals("domain", doc.get("graph_id"));
+    }
+
+    @Test
+    public void testAddsNodeId() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("id", 12345L);
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertEquals(12345L, doc.get("node_id"));
+        assertNull(doc.get("id")); // original "id" key should be skipped
+    }
+
+    // --- Ignored fields ---
+
+    @Test
+    public void testDropsIgnoredFields() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("name", "Test");
+        props.put("body", "<html>large content</html>");
+        props.put("responseDeclaration", "{\"response1\":{}}");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertNull(doc.get("body"));
+        assertNull(doc.get("responseDeclaration"));
+        assertEquals("Test", doc.get("name"));
+    }
+
+    // --- Restricted object types ---
+
+    @Test
+    public void testReturnsNullForRestrictedObjectType() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_999");
+        props.put("IL_FUNC_OBJECT_TYPE", "EventSet");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertNull(doc);
+    }
+
+    @Test
+    public void testAllowsNonRestrictedObjectType() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertNotNull(doc);
+    }
+
+    // --- JSON string deserialization (mirrors buildCompositeIndexerFromGraph) ---
+    // All {/[ strings get deserialized regardless of nestedFields config
+
+    @Test
+    public void testDeserializesJsonArrayString() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("badgeAssertions", "[{\"id\":\"badge1\"},{\"id\":\"badge2\"}]");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertTrue(doc.get("badgeAssertions") instanceof List);
+        List<?> badges = (List<?>) doc.get("badgeAssertions");
+        assertEquals(2, badges.size());
+    }
+
+    @Test
+    public void testDeserializesJsonObjectString() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("targets", "{\"id\":\"target1\"}");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertTrue(doc.get("targets") instanceof Map);
+    }
+
+    @Test
+    public void testDeserializesJsonObjectStringNotInNestedFields() {
+        // credentials, trackable etc. are NOT in nestedFields config
+        // but should still be deserialized (same as Flink graph-read path)
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("credentials", "{\"enabled\":\"No\"}");
+        props.put("trackable", "{\"enabled\":\"No\",\"autoBatch\":\"No\"}");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertTrue(doc.get("credentials") instanceof Map);
+        assertTrue(doc.get("trackable") instanceof Map);
+        assertEquals("No", ((Map<?, ?>) doc.get("credentials")).get("enabled"));
+    }
+
+    @Test
+    public void testDeserializesJsonArrayStringNotInNestedFields() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("keywords", "[\"math\",\"science\"]");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertTrue(doc.get("keywords") instanceof List);
+        List<?> keywords = (List<?>) doc.get("keywords");
+        assertEquals(2, keywords.size());
+    }
+
+    @Test
+    public void testKeepsNonJsonStringAsIs() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("name", "plain text value");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertEquals("plain text value", doc.get("name"));
+    }
+
+    @Test
+    public void testInvalidJsonKeptAsString() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("someField", "[invalid json");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertEquals("[invalid json", doc.get("someField"));
+    }
+
+    // --- String-only fields ---
+
+    @Test
+    public void testStringOnlyFieldSerializesListToJson() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("options", Arrays.asList("opt1", "opt2"));
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertTrue(doc.get("options") instanceof String);
+        assertEquals("[\"opt1\",\"opt2\"]", doc.get("options"));
+    }
+
+    @Test
+    public void testStringOnlyFieldSerializesMapToJson() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        Map<String, Object> editorState = new HashMap<>();
+        editorState.put("key", "value");
+        props.put("editorState", editorState);
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertTrue(doc.get("editorState") instanceof String);
+        assertTrue(((String) doc.get("editorState")).contains("\"key\""));
+    }
+
+    @Test
+    public void testStringOnlyFieldKeepsStringAsIs() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("editorState", "{\"already\":\"a string\"}");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        // stringOnlyFields: strings stay as strings (not deserialized)
+        assertEquals("{\"already\":\"a string\"}", doc.get("editorState"));
+    }
+
+    // --- Empty list handling (Flink getIndexDocument: empty list → null → removed) ---
+
+    @Test
+    public void testEmptyListRemovedFromDocument() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("keywords", new ArrayList<>());
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertFalse(doc.containsKey("keywords"));
+    }
+
+    // --- Regular fields ---
+
+    @Test
+    public void testRegularFieldKeepsPlainString() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("name", "Test Content");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertEquals("Test Content", doc.get("name"));
+    }
+
+    @Test
+    public void testRegularFieldKeepsNonStringTypes() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("size", 1024);
+        props.put("live", true);
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertEquals(1024, doc.get("size"));
+        assertEquals(true, doc.get("live"));
+    }
+
+    // --- Truncation ---
+
+    @Test
+    public void testTruncatesLongStrings() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        StringBuilder longValue = new StringBuilder();
+        for (int i = 0; i < 35000; i++) longValue.append("x");
+        props.put("description", longValue.toString());
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertEquals(32000, ((String) doc.get("description")).length());
+    }
+
+    @Test
+    public void testDoesNotTruncateShortStrings() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("name", "Short string");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertEquals("Short string", doc.get("name"));
+    }
+
+    // --- JanusGraph internal fields ---
+
+    @Test
+    public void testSkipsJanusGraphInternalFields() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("T.id", 12345);
+        props.put("T.label", "vertex");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertNull(doc.get("T.id"));
+        assertNull(doc.get("T.label"));
+    }
+
+    // --- Null handling ---
+
+    @Test
+    public void testNullValueRemovedFromDocument() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("IL_UNIQUE_ID", "do_123");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("description", null);
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        assertFalse(doc.containsKey("description"));
+    }
+
+    // --- Full document structure ---
+
+    @Test
+    public void testFullTransformation() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("id", 99999L);
+        props.put("IL_UNIQUE_ID", "do_555");
+        props.put("IL_FUNC_OBJECT_TYPE", "Content");
+        props.put("IL_SYS_NODE_TYPE", "DATA_NODE");
+        props.put("name", "Math Lesson");
+        props.put("status", "Live");
+        props.put("body", "<html>heavy</html>");
+        props.put("responseDeclaration", "{}");
+        props.put("keywords", "[\"math\",\"grade5\"]");
+        props.put("badgeAssertions", "[{\"id\":\"b1\"}]");
+        props.put("editorState", Arrays.asList("state1"));
+        props.put("credentials", "{\"enabled\":\"No\"}");
+        props.put("T.label", "vertex");
+
+        Map<String, Object> doc = transformer.transform(props);
+
+        // Renamed
+        assertEquals("do_555", doc.get("identifier"));
+        assertEquals("Content", doc.get("objectType"));
+        assertEquals("DATA_NODE", doc.get("nodeType"));
+
+        // System fields
+        assertEquals("domain", doc.get("graph_id"));
+        assertEquals(99999L, doc.get("node_id"));
+
+        // Regular fields
+        assertEquals("Math Lesson", doc.get("name"));
+        assertEquals("Live", doc.get("status"));
+
+        // Ignored
+        assertNull(doc.get("body"));
+        assertNull(doc.get("responseDeclaration"));
+
+        // JSON array deserialized
+        assertTrue(doc.get("keywords") instanceof List);
+
+        // JSON object deserialized (even though not in nestedFields config)
+        assertTrue(doc.get("badgeAssertions") instanceof List);
+        assertTrue(doc.get("credentials") instanceof Map);
+
+        // String-only field serialized back to string
+        assertTrue(doc.get("editorState") instanceof String);
+
+        // JanusGraph internals skipped
+        assertNull(doc.get("T.label"));
+        assertNull(doc.get("id"));
+    }
+}

--- a/taxonomy-api/taxonomy-service/conf/application.conf
+++ b/taxonomy-api/taxonomy-service/conf/application.conf
@@ -313,6 +313,9 @@ objectcategorydefinition.keyspace=dev_category_store
 # has no cloud-storage actors. Enable it if cloud-using actors are added in the future
 # (also add mimetype-manager dependency to taxonomy-service pom.xml at that point).
 cloud_storage_type="azure"
+# cloud_storage_region: AWS S3 only — region of the bucket. Ignored by Azure.
+# Leave unset for us-east-1 (SDK default); required for buckets in any other AWS region.
+#cloud_storage_region="ap-south-1"
 # ACCESS_KEY for local dev; OIDC for production K8s (Azure Workload Identity)
 cloud_storage_auth_type="ACCESS_KEY"
 cloud_storage_key=""


### PR DESCRIPTION
## Summary
Merges `develop` into `v.1.0.2` with conflict resolution. Replaces #1276.

### Conflict resolution
- Keeps CSP profiles from develop (azure/aws/gcp/oci build profiles via `-P` flag)
- Removes hardcoded `cloud-storage-sdk-azure` dependency (now handled via profiles)
- Bumps all `cloud-storage-sdk` versions in profiles from `2.0.1` → `2.0.2`

### Files with conflicts resolved
- `content-api/content-service/pom.xml`
- `knowlg-service/pom.xml`