### PR TITLE
feat(schema): add text/html mimeType for Roleplay content

### DIFF
--- a/schemas/content/1.0/schema.json
+++ b/schemas/content/1.0/schema.json
@@ -63,6 +63,7 @@
         "application/vnd.ekstep.h5p-archive",
         "application/epub",
         "text/x-url",
+        "text/html",
         "video/x-youtube",
         "application/octet-stream",
         "application/msword",


### PR DESCRIPTION
Roleplay content is authored as HTML, which wasn't previously an allowed mimeType value for the Content object type.