### PR TITLE
fix(security): disable Netty wire logging that dumps request/response bodies

### DIFF
--- a/assessment-api/assessment-service/conf/application.conf
+++ b/assessment-api/assessment-service/conf/application.conf
@@ -233,7 +233,7 @@ parsers.anyContent.maxLength = 10MB
 # ~~~~~
 play.server.netty {
   # Whether the Netty wire should be logged
-  log.wire = true
+  log.wire = false
 
   # If you run Play on Linux, you can use Netty's native socket transport
   # for higher performance with less garbage.

--- a/content-api/content-service/conf/application.conf
+++ b/content-api/content-service/conf/application.conf
@@ -236,7 +236,7 @@ play.server.provider = play.core.server.PekkoHttpServerProvider
 # ~~~~~
 play.server.netty {
   # Whether the Netty wire should be logged
-  log.wire = true
+  log.wire = false
 
   # Use NIO transport instead of native for better container compatibility
   # Changed from "native" to "jdk" to avoid TCP_FASTOPEN issues in containers

--- a/knowlg-automation/helm_charts/content/templates/content-configmap.yaml
+++ b/knowlg-automation/helm_charts/content/templates/content-configmap.yaml
@@ -267,7 +267,7 @@ data:
     # ~~~~~
     play.server.netty {
         # Whether the Netty wire should be logged
-        log.wire = true
+        log.wire = false
 
         # If you run Play on Linux, you can use Netty's native socket transport
         # for higher performance with less garbage.

--- a/knowlg-automation/helm_charts/search/templates/search-configmap.yaml
+++ b/knowlg-automation/helm_charts/search/templates/search-configmap.yaml
@@ -244,7 +244,7 @@ data:
     # ~~~~~
     play.server.netty {
       # Whether the Netty wire should be logged
-      log.wire = true
+      log.wire = false
 
       # If you run Play on Linux, you can use Netty's native socket transport
       # for higher performance with less garbage.

--- a/knowlg-automation/helm_charts/taxonomy/templates/taxonomy-configmap.yaml
+++ b/knowlg-automation/helm_charts/taxonomy/templates/taxonomy-configmap.yaml
@@ -242,7 +242,7 @@ data:
     # ~~~~~
     play.server.netty {
       # Whether the Netty wire should be logged
-      log.wire = true
+      log.wire = false
 
       # If you run Play on Linux, you can use Netty's native socket transport
       # for higher performance with less garbage.

--- a/search-api/search-service/conf/application.conf
+++ b/search-api/search-service/conf/application.conf
@@ -157,7 +157,7 @@ play.server.provider = play.core.server.PekkoHttpServerProvider
 # ~~~~~
 play.server.netty {
   # Whether the Netty wire should be logged
-  log.wire = true
+  log.wire = false
 
   # If you run Play on Linux, you can use Netty's native socket transport
   # for higher performance with less garbage.

--- a/taxonomy-api/taxonomy-service/conf/application.conf
+++ b/taxonomy-api/taxonomy-service/conf/application.conf
@@ -157,7 +157,7 @@ play.server.provider = play.core.server.PekkoHttpServerProvider
 # ~~~~~
 play.server.netty {
   # Whether the Netty wire should be logged
-  log.wire = true
+  log.wire = false
 
   # If you run Play on Linux, you can use Netty's native socket transport
   # for higher performance with less garbage.


### PR DESCRIPTION
## Summary
Log-hygiene slice for knowledge-platform (PLAN.md quick-win #3). `play.server.netty { log.wire = true }` was set in **4 service confs** (content, search, taxonomy, assessment) and their **3 Helm configmaps**.

### Why it matters
Netty wire logging emits the **full request/response bytes** — headers (including `x-authenticated-*` identity headers / bearer tokens) and bodies (user PII) — into the application logs, which then flow into shared log pipelines. That's a credential/PII leak.

### The change
`log.wire = false` in all 7 files. Config/values-only — no code or API impact.

> The active server provider is `PekkoHttpServerProvider`, so for the current deployment this is **hardening / defense-in-depth** (and corrects a misleading `true`); it fully closes the leak on any environment that runs the Netty server backend.

_Note: the working tree had unrelated pre-existing `build/*` deletions; this branch contains only the 7 `log.wire` changes._