### PR TITLE
fix(assessment-api): questionset/v2/add fails with 500 when target section already has children

### DIFF
--- a/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/managers/HierarchyManager.scala
+++ b/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/managers/HierarchyManager.scala
@@ -462,9 +462,13 @@ object HierarchyManager {
             existingLeafNodes.map(en => {
                 leafNodeMap.get(en._1).put("index", en._2.get("index").asInstanceOf[Integer])
             })
-            filteredLeafNodes = childList.asScala.filter(existingLeafNode => {
+            // new util.ArrayList(...) — NOT .toList.asJava, which wraps an
+            // immutable Scala List in a java.util.List view; the .add(node)
+            // call below then throws UnsupportedOperationException whenever
+            // the target section already had at least one existing child.
+            filteredLeafNodes = new util.ArrayList[java.util.Map[String, AnyRef]](childList.asScala.filter(existingLeafNode => {
                 !leafNodeIds.contains(existingLeafNode.get("identifier").asInstanceOf[String])
-            }).toList.asJava
+            }).asJavaCollection)
             maxIndex = childMap.values.map(child => child.get("index").asInstanceOf[Integer]).max.asInstanceOf[Integer]
         }
         leafNodeIds.foreach(id => {


### PR DESCRIPTION
## Summary

`PATCH questionset/v2/add` throws `UnsupportedOperationException` → `ERR_SYSTEM_EXCEPTION` (500 Internal Server Error) whenever the target section already has at least one existing child. It only succeeds when attaching to a section that's still empty.

## Root cause

In `HierarchyManager.restructureUnit` (`assessment-api/qs-hierarchy-manager`), when the target section already has children:

```scala
filteredLeafNodes = childList.asScala.filter(...).toList.asJava
```

`.toList.asJava` wraps an **immutable** Scala `List` in a `java.util.List` view. The next block calls `filteredLeafNodes.add(node)` to insert the new leaf — which throws `UnsupportedOperationException` against that immutable-backed list. When the section starts empty, `filteredLeafNodes` is instead the mutable `ArrayList` declared earlier in the function, so no crash — which is exactly why this only reproduces once a section has ≥1 existing child.

## Fix

Wrap the filtered result in a real mutable `ArrayList`:

```scala
filteredLeafNodes = new util.ArrayList[java.util.Map[String, AnyRef]](
  childList.asScala.filter(...).asJavaCollection
)
```

This also brings it in line with the equivalent (already-correct) `restructureUnit` in the content-api `HierarchyManager`, which builds `filteredLeafNodes` the same way and never had this bug.
