### PR TITLE
feat: Scorm MaxAttempts

### DIFF
--- a/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
+++ b/platform-modules/mimetype-manager/src/main/scala/org/sunbird/mimetype/mgr/impl/ScormMimeTypeMgrImpl.scala
@@ -27,6 +27,7 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
                         val manifestXml  = getSecureXml(manifestFile)
                         val scormVersion = detectScormVersion(manifestXml)
                         val scoList      = getScoList(manifestXml, scormVersion)
+                        val maxAttempts  = detectMaxAttempts(manifestXml, scormVersion)
 
                         if (scoList.isEmpty)
                             throw new ClientException("ERR_INVALID_FILE", "No SCOs found in imsmanifest.xml!")
@@ -48,17 +49,17 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
                         
                         extractPackageInCloud(objectId, uploadFile, node, "snapshot", false)
 
-                        Future(
-                            Map[String, AnyRef](
-                                "identifier"   -> objectId,
-                                "artifactUrl"  -> urls(IDX_S3_URL),
-                                "s3Key"        -> urls(IDX_S3_KEY),
-                                "size"         -> getFileSize(uploadFile).asInstanceOf[AnyRef],
-                                "launchFile"   -> launchFile,
-                                "scoList"      -> javaScoList,
-                                "scormVersion" -> scormVersion
-                            )
+                        val baseResult = Map[String, AnyRef](
+                            "identifier"   -> objectId,
+                            "artifactUrl"  -> urls(IDX_S3_URL),
+                            "s3Key"        -> urls(IDX_S3_KEY),
+                            "size"         -> getFileSize(uploadFile).asInstanceOf[AnyRef],
+                            "launchFile"   -> launchFile,
+                            "scoList"      -> javaScoList,
+                            "scormVersion" -> scormVersion
                         )
+
+                        Future(maxAttempts.fold(baseResult)(limit => baseResult + ("maxAttempts" -> limit.asInstanceOf[AnyRef])))
 
                     } else {
                         TelemetryManager.error("ERR_INVALID_FILE:: Invalid SCORM package: imsmanifest.xml not found for objectId: " + objectId)
@@ -88,6 +89,12 @@ class ScormMimeTypeMgrImpl(implicit ss: StorageService) extends BaseMimeTypeMana
                 throw new ClientException("ERR_INVALID_FILE",
                     "Unsupported SCORM version. Only SCORM 1.2 and SCORM 2004 are supported.")
         }
+    }
+
+    private def detectMaxAttempts(xml: Elem, scormVersion: String): Option[Int] = {
+        if (scormVersion != "2004") None
+        else (xml \\ "limitConditions").flatMap(_.attribute("attemptLimit").map(_.text.trim)).headOption
+            .flatMap(v => scala.util.Try(v.toInt).toOption)
     }
 
 private def getValidatedLaunchFile(extractionBasePath: String, launchFile: String): String = {

--- a/scripts/definition-scripts/SCORM_Content.sh
+++ b/scripts/definition-scripts/SCORM_Content.sh
@@ -26,6 +26,9 @@ curl -L -X POST '{{host}}/object/category/definition/v4/create' \
                   "parameters": { "type": "string" }
                 }
               }
+            },
+            "maxAttempts": {
+              "type": "number"
             }
           }
         }


### PR DESCRIPTION
- SCORM 2004: reads `attemptLimit` off `<imsss:limitConditions>` in `imsmanifest.xml` (IMS Simple Sequencing), alongside the existing `scoList`/`scormVersion` extraction in `ScormMimeTypeMgrImpl`.
- SCORM 1.2: no equivalent field in the spec — `maxAttempts` stays absent (unlimited), matching existing "not mentioned = no limit" semantics.
- Stored under the same `maxAttempts` metadata key already used for QuestionSet, so `course/v1/hierarchy` returns it for SCORM nodes with zero portal-side changes.
- Added `maxAttempts` to the `obj-cat:scorm-content` category definition (`scripts/definition-scripts/SCORM_Content.sh`) alongside `launchFile`/`scormVersion`/`scoList`.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [x] Uploaded a SCORM 2004 package with `<imsss:limitConditions attemptLimit="N">` in `imsmanifest.xml`, verified `maxAttempts` returned on `content/v3/read`
- [x] Uploaded a SCORM 1.2 package, verified `maxAttempts` is absent
- [x] Re-applied the `obj-cat:scorm-content` category definition update and verified schema validation accepts `maxAttempts`

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules