### PR TITLE
fix: store collection relation cache in Redis when enabled

### DIFF
--- a/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/RelationManager.scala
+++ b/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/RelationManager.scala
@@ -2,6 +2,7 @@ package org.sunbird.managers.content
 
 import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
+import org.sunbird.cache.impl.RedisCache
 import org.sunbird.common.Platform
 import org.sunbird.common.dto.{Request, Response, ResponseHandler}
 import org.sunbird.common.exception.{ClientException, ErrorCodes, ResponseCode}
@@ -27,6 +28,8 @@ object RelationManager {
 
     private val primaryKey: java.util.List[String] = java.util.Arrays.asList("relationship_key")
     private val propsMapping: Map[String, String] = Map("node_ids" -> "")
+
+    private val isRedisEnabled: Boolean = Platform.getBoolean("redis.enable", false)
 
 
     def updateHierarchyRelationships(request: Request)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Response] = {
@@ -173,26 +176,33 @@ object RelationManager {
         if (CollectionUtils.isEmpty(children)) new java.util.ArrayList[util.Map[String, AnyRef]]() else children
     }
 
+    private def relationshipKey(rootId: String, identifier: String, relationshipType: String): String =
+        if (StringUtils.isNotBlank(rootId)) s"$rootId:$identifier:$relationshipType"
+        else s"$identifier:$relationshipType"
+
     private def storeRelationshipData(
         rootId           : String,
         relationshipType : String,
         dataMap          : Map[String, List[String]]
     )(implicit ec: ExecutionContext): Future[List[Response]] = {
-        val store = ExternalStoreFactory.getExternalStore(
-            s"$relationCacheKeyspace.$relationCacheTable", primaryKey)
+        if (isRedisEnabled) {
+            dataMap.foreach { case (identifier, nodeIds) =>
+                RedisCache.saveList(relationshipKey(rootId, identifier, relationshipType), nodeIds)
+            }
+            Future.successful(List(ResponseHandler.OK))
+        } else {
+            val store = ExternalStoreFactory.getExternalStore(
+                s"$relationCacheKeyspace.$relationCacheTable", primaryKey)
 
-        val futures = dataMap.map { case (identifier, nodeIds) =>
-            val relationshipKey =
-                if (StringUtils.isNotBlank(rootId)) s"$rootId:$identifier:$relationshipType"
-                else s"$identifier:$relationshipType"
-
-            store.update(
-                relationshipKey,
-                List("node_ids"),
-                List(nodeIds.asJava.asInstanceOf[AnyRef]),
-                propsMapping
-            )
+            val futures = dataMap.map { case (identifier, nodeIds) =>
+                store.update(
+                    relationshipKey(rootId, identifier, relationshipType),
+                    List("node_ids"),
+                    List(nodeIds.asJava.asInstanceOf[AnyRef]),
+                    propsMapping
+                )
+            }
+            Future.sequence(futures.toList)
         }
-        Future.sequence(futures.toList)
     }
 }


### PR DESCRIPTION
Adds a Redis-backed path for the collection hierarchy relationship-rebuild API, part of a larger cross-repo change (knowlg-publish job now writes hierarchy data to Redis on publish; lern-service /content/state/update now reads from Redis) — this repo's piece covers the "rebuild if missing" API.

POST /collection/v4/hierarchy/update/relation/:identifier → RelationManager.updateHierarchyRelationships computes leaf-node, optional-node, and ancestor-node maps from a collection's hierarchy and persists them. Previously always wrote to the Yugabyte-backed hierarchy_relations Cassandra table via ExternalStore. Now, when redis.enable=true, it writes each map as a simple key → node-id-list entry in Redis via the existing RedisCache.saveList, keyed as $rootId:$identifier:$relationshipType (same key shape as before). Falls back to the existing Yugabyte path when Redis is disabled — no schema/config changes required, no new dependency (module already pulls in platform-cache transitively via graph-engine, same as HierarchyManager.scala in this module).

Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules