### PR TITLE
feat: store collection relation cache in Redis when enabled- #1305

### DIFF
--- a/content-api/content-service/conf/application.conf
+++ b/content-api/content-service/conf/application.conf
@@ -397,6 +397,7 @@ redis.host = "localhost"
 redis.port = 6379
 redis.maxConnections = 128
 redis.enable = false
+redis.database.hierarchyRelations.id = 10
 
 #Condition to enable publish locally
 content.publish_task.enabled=true

--- a/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/RelationManager.scala
+++ b/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/RelationManager.scala
@@ -2,6 +2,7 @@ package org.sunbird.managers.content
 
 import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
+import org.sunbird.cache.impl.RedisCache
 import org.sunbird.common.Platform
 import org.sunbird.common.dto.{Request, Response, ResponseHandler}
 import org.sunbird.common.exception.{ClientException, ErrorCodes, ResponseCode}
@@ -27,6 +28,8 @@ object RelationManager {
 
     private val primaryKey: java.util.List[String] = java.util.Arrays.asList("relationship_key")
     private val propsMapping: Map[String, String] = Map("node_ids" -> "")
+
+    private val isRedisEnabled: Boolean = Platform.getBoolean("redis.enable", false)
 
 
     def updateHierarchyRelationships(request: Request)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Response] = {
@@ -173,26 +176,33 @@ object RelationManager {
         if (CollectionUtils.isEmpty(children)) new java.util.ArrayList[util.Map[String, AnyRef]]() else children
     }
 
+    private def relationshipKey(rootId: String, identifier: String, relationshipType: String): String =
+        if (StringUtils.isNotBlank(rootId)) s"$rootId:$identifier:$relationshipType"
+        else s"$identifier:$relationshipType"
+
     private def storeRelationshipData(
         rootId           : String,
         relationshipType : String,
         dataMap          : Map[String, List[String]]
     )(implicit ec: ExecutionContext): Future[List[Response]] = {
-        val store = ExternalStoreFactory.getExternalStore(
-            s"$relationCacheKeyspace.$relationCacheTable", primaryKey)
+        if (isRedisEnabled) {
+            dataMap.foreach { case (identifier, nodeIds) =>
+                RedisCache.saveList(relationshipKey(rootId, identifier, relationshipType), nodeIds)
+            }
+            Future.successful(List(ResponseHandler.OK))
+        } else {
+            val store = ExternalStoreFactory.getExternalStore(
+                s"$relationCacheKeyspace.$relationCacheTable", primaryKey)
 
-        val futures = dataMap.map { case (identifier, nodeIds) =>
-            val relationshipKey =
-                if (StringUtils.isNotBlank(rootId)) s"$rootId:$identifier:$relationshipType"
-                else s"$identifier:$relationshipType"
-
-            store.update(
-                relationshipKey,
-                List("node_ids"),
-                List(nodeIds.asJava.asInstanceOf[AnyRef]),
-                propsMapping
-            )
+            val futures = dataMap.map { case (identifier, nodeIds) =>
+                store.update(
+                    relationshipKey(rootId, identifier, relationshipType),
+                    List("node_ids"),
+                    List(nodeIds.asJava.asInstanceOf[AnyRef]),
+                    propsMapping
+                )
+            }
+            Future.sequence(futures.toList)
         }
-        Future.sequence(futures.toList)
     }
 }

--- a/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/RelationManager.scala
+++ b/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/RelationManager.scala
@@ -2,13 +2,13 @@ package org.sunbird.managers.content
 
 import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
-import org.sunbird.cache.impl.HierarchyRelationCache
 import org.sunbird.common.Platform
 import org.sunbird.common.dto.{Request, Response, ResponseHandler}
 import org.sunbird.common.exception.{ClientException, ErrorCodes, ResponseCode}
 import org.sunbird.graph.OntologyEngineContext
 import org.sunbird.graph.external.store.ExternalStoreFactory
 import org.sunbird.telemetry.logger.TelemetryManager
+import org.sunbird.utils.content.HierarchyRelationCache
 
 import java.util
 import scala.concurrent.{ExecutionContext, Future}

--- a/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/RelationManager.scala
+++ b/content-api/hierarchy-manager/src/main/scala/org/sunbird/managers/RelationManager.scala
@@ -2,7 +2,7 @@ package org.sunbird.managers.content
 
 import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
-import org.sunbird.cache.impl.RedisCache
+import org.sunbird.cache.impl.HierarchyRelationCache
 import org.sunbird.common.Platform
 import org.sunbird.common.dto.{Request, Response, ResponseHandler}
 import org.sunbird.common.exception.{ClientException, ErrorCodes, ResponseCode}
@@ -187,7 +187,7 @@ object RelationManager {
     )(implicit ec: ExecutionContext): Future[List[Response]] = {
         if (isRedisEnabled) {
             dataMap.foreach { case (identifier, nodeIds) =>
-                RedisCache.saveList(relationshipKey(rootId, identifier, relationshipType), nodeIds)
+                HierarchyRelationCache.replaceSet(relationshipKey(rootId, identifier, relationshipType), nodeIds)
             }
             Future.successful(List(ResponseHandler.OK))
         } else {

--- a/content-api/hierarchy-manager/src/main/scala/org/sunbird/utils/HierarchyRelationCache.scala
+++ b/content-api/hierarchy-manager/src/main/scala/org/sunbird/utils/HierarchyRelationCache.scala
@@ -1,4 +1,4 @@
-package org.sunbird.cache.impl
+package org.sunbird.utils.content
 
 import org.slf4j.{Logger, LoggerFactory}
 import org.sunbird.cache.util.RedisConnector
@@ -22,7 +22,7 @@ object HierarchyRelationCache extends RedisConnector {
 				val jedis = getConnection
 				try {
 					jedis.del(key)
-					if (data.nonEmpty) jedis.sadd(key, data: _*)
+					data.foreach(entry => jedis.sadd(key, entry))
 				} catch {
 					case e: Exception =>
 						logger.error("Exception Occurred While Saving Set Data to HierarchyRelationCache for Key : " + key + "| Exception is:", e)

--- a/knowlg-service/conf/application.conf
+++ b/knowlg-service/conf/application.conf
@@ -471,6 +471,7 @@ redis.host = "localhost"
 redis.port = 6379
 redis.maxConnections = 128
 redis.enable = false
+redis.database.hierarchyRelations.id = 10
 
 #Condition to enable publish locally
 content.publish_task.enabled=true

--- a/platform-core/platform-cache/src/main/scala/org/sunbird/cache/impl/HierarchyRelationCache.scala
+++ b/platform-core/platform-cache/src/main/scala/org/sunbird/cache/impl/HierarchyRelationCache.scala
@@ -1,0 +1,36 @@
+package org.sunbird.cache.impl
+
+import org.slf4j.{Logger, LoggerFactory}
+import org.sunbird.cache.util.RedisConnector
+import org.sunbird.common.Platform
+
+/**
+ * Redis-backed store for collection hierarchy relationship data (leaf nodes,
+ * optional nodes, ancestors). Kept on its own db index — separate from the
+ * general-purpose RedisCache index — so it lines up with the same dedicated
+ * index used by knowledge-platform-jobs (redis.database.hierarchyRelations.id)
+ * and lern-service (hierarchy_relations_redis_index).
+ */
+object HierarchyRelationCache extends RedisConnector {
+
+	private val logger: Logger = LoggerFactory.getLogger(HierarchyRelationCache.getClass.getCanonicalName)
+	override protected val dbIndex: Int = Platform.getInteger("redis.database.hierarchyRelations.id", 10)
+
+	def replaceSet(key: String, data: List[String]): Unit = {
+		if (isEnabled) {
+			try {
+				val jedis = getConnection
+				try {
+					jedis.del(key)
+					if (data.nonEmpty) jedis.sadd(key, data: _*)
+				} catch {
+					case e: Exception =>
+						logger.error("Exception Occurred While Saving Set Data to HierarchyRelationCache for Key : " + key + "| Exception is:", e)
+				} finally returnConnection(jedis)
+			} catch {
+				case e: Exception =>
+					logger.error("Redis Connection/Authentication Error for Key : " + key + "| Exception is:", e)
+			}
+		}
+	}
+}

--- a/platform-core/platform-cache/src/main/scala/org/sunbird/cache/util/RedisConnector.scala
+++ b/platform-core/platform-cache/src/main/scala/org/sunbird/cache/util/RedisConnector.scala
@@ -12,7 +12,7 @@ trait RedisConnector {
 	private val HOST = Platform.getString("redis.host", "localhost")
 	private val PORT = Platform.getInteger("redis.port", 6379)
 	private val MAX_CONNECTIONS = Platform.getInteger("redis.maxConnections", 128)
-	private val INDEX = Platform.getInteger("redis.dbIndex", 0)
+	protected val dbIndex: Int = Platform.getInteger("redis.dbIndex", 0)
 	private val PASSWORD: String = Platform.getString("redis.password", "")
 	protected val isEnabled: Boolean = Platform.getBoolean("redis.enable", false)
 
@@ -42,7 +42,7 @@ trait RedisConnector {
 	 */
 	protected def getConnection: Jedis = if (!isEnabled) null else {
 		val jedis = jedisPool.getResource
-		if (INDEX > 0) jedis.select(INDEX)
+		if (dbIndex > 0) jedis.select(dbIndex)
 		jedis
 	}
 


### PR DESCRIPTION
Adds a Redis-backed path for the collection hierarchy relationship-rebuild API, part of a larger cross-repo change (knowlg-publish job now writes hierarchy data to Redis on publish; lern-service /content/state/update now reads from Redis) — this repo's piece covers the "rebuild if missing" API.

POST /collection/v4/hierarchy/update/relation/:identifier → RelationManager.updateHierarchyRelationships computes leaf-node, optional-node, and ancestor-node maps from a collection's hierarchy and persists them. Previously always wrote to the Yugabyte-backed hierarchy_relations Cassandra table via ExternalStore. Now, when redis.enable=true, it writes each map as a simple key → node-id-list entry in Redis via the existing RedisCache.saveList, keyed as $rootId:$identifier:$relationshipType (same key shape as before). Falls back to the existing Yugabyte path when Redis is disabled — no schema/config changes required, no new dependency (module already pulls in platform-cache transitively via graph-engine, same as HierarchyManager.scala in this module).

Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules